### PR TITLE
Adds CBC standards for tokens and metadata

### DIFF
--- a/cip/cbc/cip-108.md
+++ b/cip/cbc/cip-108.md
@@ -40,7 +40,7 @@ The motivation behind this CIP is to provide a secure and controlled way to exec
 
 - Secure Transaction Execution: Facilitates the execution of external transactions in a controlled environment.
 - Contract Authentication: Only authorized contracts (specified at deployment) can call their functions.
-- Gas Limit Specification: Allows specifying a gas limit for executing transactions to manage transaction costs effectively.
+- Energy Limit Specification: Allows specifying an energy limit for executing transactions to manage transaction costs effectively.
 
 ### Technical Details
 

--- a/cip/cbc/cip-1155.md
+++ b/cip/cbc/cip-1155.md
@@ -1,0 +1,719 @@
+---
+cip: 1155
+title: Multi Token Standard
+description: >-
+  A standardized smart contract interface for managing multiple token types (fungible, non-fungible, and semi-fungible) in a single contract on Core Blockchain (CBC).
+keywords:
+  - cip
+  - cip-1155
+  - cbc
+  - multi-token
+  - fungible
+  - non-fungible
+  - semi-fungible
+  - standard
+  - asset management
+author: Rastislav Vašička <rastislav@onion.email>
+lang: en-US
+status: draft
+tags:
+  - cbc
+date: 2025-07-06T00:00:00.000Z
+requires:
+  - cip-165
+---
+
+A standardized smart contract interface for managing multiple token types (fungible, non-fungible, and semi-fungible) in a single contract on Core Blockchain (CBC).
+
+<!--truncate-->
+
+## Abstract
+
+This standard outlines a smart contract interface that can represent any number of fungible and non-fungible token types. Existing standards such as CBC-20 require deployment of separate contracts per token type. The CBC-721 standard's token ID is a single non-fungible index and the group of these non-fungibles is deployed as a single contract with settings for the entire collection. In contrast, the CBC-1155 Multi Token Standard allows for each token ID to represent a new configurable token type, which may have its own metadata, supply and other attributes.
+
+The `_id` argument contained in each function's argument set indicates a specific token or token type in a transaction.
+
+## Motivation
+
+Tokens standards like CBC-20 and CBC-721 require a separate contract to be deployed for each token type or collection. This places a lot of redundant bytecode on the Ethereum blockchain and limits certain functionality by the nature of separating each token contract into its own permissioned address. With the rise of blockchain games and platforms like Enjin Coin, game developers may be creating thousands of token types, and a new type of token standard is needed to support them. However, CBC-1155 is not specific to games and many other applications can benefit from this flexibility.
+
+New functionality is possible with this design such as transferring multiple token types at once, saving on transaction costs. Trading (escrow / atomic swaps) of multiple tokens can be built on top of this standard and it removes the need to "approve" individual token contracts separately. It is also easy to describe and mix multiple fungible or non-fungible token types in a single contract.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+**Smart contracts implementing the CBC-1155 standard MUST implement all of the functions in the `CBC1155` interface.**
+
+**Smart contracts implementing the CBC-1155 standard MUST implement the CBC-165 `supportsInterface` function and MUST return the constant value `true` if `0xd9b67a26` is passed through the `interfaceID` argument.**
+
+```solidity
+pragma solidity ^0.5.9;
+
+/**
+    @title CBC-1155 Multi Token Standard
+    Note: The CBC-165 identifier for this interface is 0xd9b67a26.
+ */
+interface CBC1155 /* is CBC165 */ {
+    /**
+        @dev Either `TransferSingle` or `TransferBatch` MUST emit when tokens are transferred, including zero value transfers as well as minting or burning (see "Safe Transfer Rules" section of the standard).
+        The `_operator` argument MUST be the address of an account/contract that is approved to make the transfer (SHOULD be msg.sender).
+        The `_from` argument MUST be the address of the holder whose balance is decreased.
+        The `_to` argument MUST be the address of the recipient whose balance is increased.
+        The `_id` argument MUST be the token type being transferred.
+        The `_value` argument MUST be the number of tokens the holder balance is decreased by and match what the recipient balance is increased by.
+        When minting/creating tokens, the `_from` argument MUST be set to `0x0` (i.e. zero address).
+        When burning/destroying tokens, the `_to` argument MUST be set to `0x0` (i.e. zero address).
+    */
+    event TransferSingle(address indexed _operator, address indexed _from, address indexed _to, uint256 _id, uint256 _value);
+
+    /**
+        @dev Either `TransferSingle` or `TransferBatch` MUST emit when tokens are transferred, including zero value transfers as well as minting or burning (see "Safe Transfer Rules" section of the standard).
+        The `_operator` argument MUST be the address of an account/contract that is approved to make the transfer (SHOULD be msg.sender).
+        The `_from` argument MUST be the address of the holder whose balance is decreased.
+        The `_to` argument MUST be the address of the recipient whose balance is increased.
+        The `_ids` argument MUST be the list of tokens being transferred.
+        The `_values` argument MUST be the list of number of tokens (matching the list and order of tokens specified in _ids) the holder balance is decreased by and match what the recipient balance is increased by.
+        When minting/creating tokens, the `_from` argument MUST be set to `0x0` (i.e. zero address).
+        When burning/destroying tokens, the `_to` argument MUST be set to `0x0` (i.e. zero address).
+    */
+    event TransferBatch(address indexed _operator, address indexed _from, address indexed _to, uint256[] _ids, uint256[] _values);
+
+    /**
+        @dev MUST emit when approval for a second party/operator address to manage all tokens for an owner address is enabled or disabled (absence of an event assumes disabled).
+    */
+    event ApprovalForAll(address indexed _owner, address indexed _operator, bool _approved);
+
+    /**
+        @dev MUST emit when the URI is updated for a token ID.
+        URIs are defined in RFC 3986.
+        The URI MUST point to a JSON file that conforms to the "CBC-1155 Metadata URI JSON Schema".
+    */
+    event URI(string _value, uint256 indexed _id);
+
+    /**
+        @notice Transfers `_value` amount of an `_id` from the `_from` address to the `_to` address specified (with safety call).
+        @dev Caller must be approved to manage the tokens being transferred out of the `_from` account (see "Approval" section of the standard).
+        MUST revert if `_to` is the zero address.
+        MUST revert if balance of holder for token `_id` is lower than the `_value` sent.
+        MUST revert on any other error.
+        MUST emit the `TransferSingle` event to reflect the balance change (see "Safe Transfer Rules" section of the standard).
+        After the above conditions are met, this function MUST check if `_to` is a smart contract (e.g. code size > 0). If so, it MUST call `onCBC1155Received` on `_to` and act appropriately (see "Safe Transfer Rules" section of the standard).
+        @param _from    Source address
+        @param _to      Target address
+        @param _id      ID of the token type
+        @param _value   Transfer amount
+        @param _data    Additional data with no specified format, MUST be sent unaltered in call to `onCBC1155Received` on `_to`
+    */
+    function safeTransferFrom(address _from, address _to, uint256 _id, uint256 _value, bytes calldata _data) external;
+
+    /**
+        @notice Transfers `_values` amount(s) of `_ids` from the `_from` address to the `_to` address specified (with safety call).
+        @dev Caller must be approved to manage the tokens being transferred out of the `_from` account (see "Approval" section of the standard).
+        MUST revert if `_to` is the zero address.
+        MUST revert if length of `_ids` is not the same as length of `_values`.
+        MUST revert if any of the balance(s) of the holder(s) for token(s) in `_ids` is lower than the respective amount(s) in `_values` sent to the recipient.
+        MUST revert on any other error.
+        MUST emit `TransferSingle` or `TransferBatch` event(s) such that all the balance changes are reflected (see "Safe Transfer Rules" section of the standard).
+        Balance changes and events MUST follow the ordering of the arrays (_ids[0]/_values[0] before _ids[1]/_values[1], etc).
+        After the above conditions for the transfer(s) in the batch are met, this function MUST check if `_to` is a smart contract (e.g. code size > 0). If so, it MUST call the relevant `CBC1155TokenReceiver` hook(s) on `_to` and act appropriately (see "Safe Transfer Rules" section of the standard).
+        @param _from    Source address
+        @param _to      Target address
+        @param _ids     IDs of each token type (order and length must match _values array)
+        @param _values  Transfer amounts per token type (order and length must match _ids array)
+        @param _data    Additional data with no specified format, MUST be sent unaltered in call to the `CBC1155TokenReceiver` hook(s) on `_to`
+    */
+    function safeBatchTransferFrom(address _from, address _to, uint256[] calldata _ids, uint256[] calldata _values, bytes calldata _data) external;
+
+    /**
+        @notice Get the balance of an account's tokens.
+        @param _owner  The address of the token holder
+        @param _id     ID of the token
+        @return        The _owner's balance of the token type requested
+     */
+    function balanceOf(address _owner, uint256 _id) external view returns (uint256);
+
+    /**
+        @notice Get the balance of multiple account/token pairs
+        @param _owners The addresses of the token holders
+        @param _ids    ID of the tokens
+        @return        The _owner's balance of the token types requested (i.e. balance for each (owner, id) pair)
+     */
+    function balanceOfBatch(address[] calldata _owners, uint256[] calldata _ids) external view returns (uint256[] memory);
+
+    /**
+        @notice Enable or disable approval for a third party ("operator") to manage all of the caller's tokens.
+        @dev MUST emit the ApprovalForAll event on success.
+        @param _operator  Address to add to the set of authorized operators
+        @param _approved  True if the operator is approved, false to revoke approval
+    */
+    function setApprovalForAll(address _operator, bool _approved) external;
+
+    /**
+        @notice Queries the approval status of an operator for a given owner.
+        @param _owner     The owner of the tokens
+        @param _operator  Address of authorized operator
+        @return           True if the operator is approved, false if not
+    */
+    function isApprovedForAll(address _owner, address _operator) external view returns (bool);
+}
+```
+
+### CBC-1155 Token Receiver
+
+**Smart contracts MUST implement all of the functions in the `CBC1155TokenReceiver` interface to accept transfers. See "Safe Transfer Rules" for further detail.**
+
+**Smart contracts MUST implement the CBC-165 `supportsInterface` function and signify support for the `CBC1155TokenReceiver` interface to accept transfers. See "CBC1155TokenReceiver CBC-165 rules" for further detail.**
+
+```solidity
+pragma solidity ^0.5.9;
+
+/**
+    Note: The CBC-165 identifier for this interface is 0x4e2312e0.
+*/
+interface CBC1155TokenReceiver {
+    /**
+        @notice Handle the receipt of a single CBC1155 token type.
+        @dev An CBC1155-compliant smart contract MUST call this function on the token recipient contract, at the end of a `safeTransferFrom` after the balance has been updated.
+        This function MUST return `bytes4(sha256("onCBC1155Received(address,address,uint256,uint256,bytes)"))` (i.e. 0xf23a6e61) if it accepts the transfer.
+        This function MUST revert if it rejects the transfer.
+        Return of any other value than the prescribed sha256 generated value MUST result in the transaction being reverted by the caller.
+        @param _operator  The address which initiated the transfer (i.e. msg.sender)
+        @param _from      The address which previously owned the token
+        @param _id        The ID of the token being transferred
+        @param _value     The amount of tokens being transferred
+        @param _data      Additional data with no specified format
+        @return           `bytes4(sha256("onCBC1155Received(address,address,uint256,uint256,bytes)"))`
+    */
+    function onCBC1155Received(address _operator, address _from, uint256 _id, uint256 _value, bytes calldata _data) external returns(bytes4);
+
+    /**
+        @notice Handle the receipt of multiple CBC1155 token types.
+        @dev An CBC1155-compliant smart contract MUST call this function on the token recipient contract, at the end of a `safeBatchTransferFrom` after the balances have been updated.
+        This function MUST return `bytes4(sha256("onCBC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` (i.e. 0xbc197c81) if it accepts the transfer(s).
+        This function MUST revert if it rejects the transfer(s).
+        Return of any other value than the prescribed sha256 generated value MUST result in the transaction being reverted by the caller.
+        @param _operator  The address which initiated the batch transfer (i.e. msg.sender)
+        @param _from      The address which previously owned the token
+        @param _ids       An array containing ids of each token being transferred (order and length must match _values array)
+        @param _values    An array containing amounts of each token being transferred (order and length must match _ids array)
+        @param _data      Additional data with no specified format
+        @return           `bytes4(sha256("onCBC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
+    */
+    function onCBC1155BatchReceived(address _operator, address _from, uint256[] calldata _ids, uint256[] calldata _values, bytes calldata _data) external returns(bytes4);
+}
+```
+
+### Safe Transfer Rules
+
+To be more explicit about how the standard `safeTransferFrom` and `safeBatchTransferFrom` functions MUST operate with respect to the `CBC1155TokenReceiver` hook functions, a list of scenarios and rules follows.
+
+#### Scenarios
+
+**_Scenario#1 :_** The recipient is not a contract.
+
+* `onCBC1155Received` and `onCBC1155BatchReceived` MUST NOT be called on an EOA (Externally Owned Account).
+
+**_Scenario#2 :_** The transaction is not a mint/transfer of a token.
+
+* `onCBC1155Received` and `onCBC1155BatchReceived` MUST NOT be called outside of a mint or transfer process.
+
+**_Scenario#3 :_** The receiver does not implement the necessary `CBC1155TokenReceiver` interface function(s).
+
+* The transfer MUST be reverted with the one caveat below.
+  * If the token(s) being sent are part of a hybrid implementation of another standard, that particular standard's rules on sending to a contract MAY now be followed instead. See "Backwards Compatibility" section.
+
+**_Scenario#4 :_** The receiver implements the necessary `CBC1155TokenReceiver` interface function(s) but returns an unknown value.
+
+* The transfer MUST be reverted.
+
+**_Scenario#5 :_** The receiver implements the necessary `CBC1155TokenReceiver` interface function(s) but throws an error.
+
+* The transfer MUST be reverted.
+
+**_Scenario#6 :_** The receiver implements the `CBC1155TokenReceiver` interface and is the recipient of one and only one balance change (e.g. `safeTransferFrom` called).
+
+* The balances for the transfer MUST have been updated before the `CBC1155TokenReceiver` hook is called on a recipient contract.
+* The transfer event MUST have been emitted to reflect the balance changes before the `CBC1155TokenReceiver` hook is called on the recipient contract.
+* One of `onCBC1155Received` or `onCBC1155BatchReceived` MUST be called on the recipient contract.
+* The `onCBC1155Received` hook SHOULD be called on the recipient contract and its rules followed.
+  * See "onCBC1155Received rules" for further rules that MUST be followed.
+* The `onCBC1155BatchReceived` hook MAY be called on the recipient contract and its rules followed.
+  * See "onCBC1155BatchReceived rules" for further rules that MUST be followed.
+
+**_Scenario#7 :_** The receiver implements the `CBC1155TokenReceiver` interface and is the recipient of more than one balance change (e.g. `safeBatchTransferFrom` called).
+
+* All balance transfers that are referenced in a call to an `CBC1155TokenReceiver` hook MUST be updated before the `CBC1155TokenReceiver` hook is called on the recipient contract.
+* All transfer events MUST have been emitted to reflect current balance changes before an `CBC1155TokenReceiver` hook is called on the recipient contract.
+* `onCBC1155Received` or `onCBC1155BatchReceived` MUST be called on the recipient as many times as necessary such that every balance change for the recipient in the scenario is accounted for.
+  * The return magic value for every hook call MUST be checked and acted upon as per "onCBC1155Received rules" and "onCBC1155BatchReceived rules".
+* The `onCBC1155BatchReceived` hook SHOULD be called on the recipient contract and its rules followed.
+  * See "onCBC1155BatchReceived rules" for further rules that MUST be followed.
+* The `onCBC1155Received` hook MAY be called on the recipient contract and its rules followed.
+  * See "onCBC1155Received rules" for further rules that MUST be followed.
+
+**_Scenario#8 :_** You are the creator of a contract that implements the `CBC1155TokenReceiver` interface and you forward the token(s) onto another address in one or both of `onCBC1155Received` and `onCBC1155BatchReceived`.
+
+* Forwarding should be considered acceptance and then initiating a new `safeTransferFrom` or `safeBatchTransferFrom` in a new context.
+  * The prescribed sha256 acceptance value magic for the receiver hook being called MUST be returned after forwarding is successful.
+* The `_data` argument MAY be re-purposed for the new context.
+* If forwarding fails the transaction MAY be reverted.
+  * If the contract logic wishes to keep the ownership of the token(s) itself in this case it MAY do so.
+
+**_Scenario#9 :_** You are transferring tokens via a non-standard API call i.e. an implementation specific API and NOT `safeTransferFrom` or `safeBatchTransferFrom`.
+
+* In this scenario all balance updates and events output rules are the same as if a standard transfer function had been called.
+  * i.e. an external viewer MUST still be able to query the balance via a standard function and it MUST be identical to the balance as determined by `TransferSingle` and `TransferBatch` events alone.
+* If the receiver is a contract the `CBC1155TokenReceiver` hooks still need to be called on it and the return values respected the same as if a standard transfer function had been called.
+  * However while the `safeTransferFrom` or `safeBatchTransferFrom` functions MUST revert if a receiving contract does not implement the `CBC1155TokenReceiver` interface, a non-standard function MAY proceed with the transfer.
+  * See "Implementation specific transfer API rules".
+
+#### Rules
+
+**_safeTransferFrom rules:_**
+
+* Caller must be approved to manage the tokens being transferred out of the `_from` account (see "Approval" section).
+* MUST revert if `_to` is the zero address.
+* MUST revert if balance of holder for token `_id` is lower than the `_value` sent to the recipient.
+* MUST revert on any other error.
+* MUST emit the `TransferSingle` event to reflect the balance change (see "TransferSingle and TransferBatch event rules" section).
+* After the above conditions are met, this function MUST check if `_to` is a smart contract (e.g. code size > 0). If so, it MUST call `onCBC1155Received` on `_to` and act appropriately (see "onCBC1155Received rules" section).
+  * The `_data` argument provided by the sender for the transfer MUST be passed with its contents unaltered to the `onCBC1155Received` hook function via its `_data` argument.
+
+**_safeBatchTransferFrom rules:_**
+
+* Caller must be approved to manage all the tokens being transferred out of the `_from` account (see "Approval" section).
+* MUST revert if `_to` is the zero address.
+* MUST revert if length of `_ids` is not the same as length of `_values`.
+* MUST revert if any of the balance(s) of the holder(s) for token(s) in `_ids` is lower than the respective amount(s) in `_values` sent to the recipient.
+* MUST revert on any other error.
+* MUST emit `TransferSingle` or `TransferBatch` event(s) such that all the balance changes are reflected (see "TransferSingle and TransferBatch event rules" section).
+* The balance changes and events MUST occur in the array order they were submitted (_ids[0]/_values[0] before _ids[1]/_values[1], etc).
+* After the above conditions are met, this function MUST check if `_to` is a smart contract (e.g. code size > 0). If so, it MUST call `onCBC1155Received` or `onCBC1155BatchReceived` on `_to` and act appropriately (see "onCBC1155Received and onCBC1155BatchReceived rules" section).
+  * The `_data` argument provided by the sender for the transfer MUST be passed with its contents unaltered to the `CBC1155TokenReceiver` hook function(s) via their `_data` argument.
+
+**_TransferSingle and TransferBatch event rules:_**
+
+* `TransferSingle` SHOULD be used to indicate a single balance transfer has occurred between a `_from` and `_to` pair.
+  * It MAY be emitted multiple times to indicate multiple balance changes in the transaction, but note that `TransferBatch` is designed for this to reduce energy consumption.
+  * The `_operator` argument MUST be the address of an account/contract that is approved to make the transfer (SHOULD be msg.sender).
+  * The `_from` argument MUST be the address of the holder whose balance is decreased.
+    * The `_to` argument MUST be the address of the recipient whose balance is increased.
+    * The `_id` argument MUST be the token type being transferred.
+    * The `_value` argument MUST be the number of tokens the holder balance is decreased by and match what the recipient balance is increased by.
+    * When minting/creating tokens, the `_from` argument MUST be set to `0x0` (i.e. zero address). See "Minting/creating and burning/destroying rules".
+    * When burning/destroying tokens, the `_to` argument MUST be set to `0x0` (i.e. zero address). See "Minting/creating and burning/destroying rules".
+* `TransferBatch` SHOULD be used to indicate multiple balance transfers have occurred between a `_from` and `_to` pair.
+  * It MAY be emitted with a single element in the list to indicate a singular balance change in the transaction, but note that `TransferSingle` is designed for this to reduce energy consumption.
+  * The `_operator` argument MUST be the address of an account/contract that is approved to make the transfer (SHOULD be msg.sender).
+  * The `_from` argument MUST be the address of the holder whose balance is decreased for each entry pair in `_ids` and `_values`.
+    * The `_to` argument MUST be the address of the recipient whose balance is increased for each entry pair in `_ids` and `_values`.
+    * The `_ids` array argument MUST contain the ids of the tokens being transferred.
+    * The `_values` array argument MUST contain the number of token to be transferred for each corresponding entry in `_ids`.
+    * `_ids` and `_values` MUST have the same length.
+    * When minting/creating tokens, the `_from` argument MUST be set to `0x0` (i.e. zero address). See "Minting/creating and burning/destroying rules".
+    * When burning/destroying tokens, the `_to` argument MUST be set to `0x0` (i.e. zero address). See "Minting/creating and burning/destroying rules".
+* The total value transferred from address `0x0` minus the total value transferred to `0x0` observed via the `TransferSingle` and `TransferBatch` events MAY be used by clients and exchanges to determine the "circulating supply" for a given token ID.
+* To broadcast the existence of a token ID with no initial balance, the contract SHOULD emit the `TransferSingle` event from `0x0` to `0x0`, with the token creator as `_operator`, and a `_value` of 0.
+* All `TransferSingle` and `TransferBatch` events MUST be emitted to reflect all the balance changes that have occurred before any call(s) to `onCBC1155Received` or `onCBC1155BatchReceived`.
+  * To make sure event order is correct in the case of valid re-entry (e.g. if a receiver contract forwards tokens on receipt) state balance and events balance MUST match before calling an external contract.
+
+**_onCBC1155Received rules:_**
+
+* The `_operator` argument MUST be the address of an account/contract that is approved to make the transfer (SHOULD be msg.sender).
+* The `_from` argument MUST be the address of the holder whose balance is decreased.
+  * `_from` MUST be 0x0 for a mint.
+* The `_id` argument MUST be the token type being transferred.
+* The `_value` argument MUST be the number of tokens the holder balance is decreased by and match what the recipient balance is increased by.
+* The `_data` argument MUST contain the information provided by the sender for the transfer with its contents unaltered.
+  * i.e. it MUST pass on the unaltered `_data` argument sent via the `safeTransferFrom` or `safeBatchTransferFrom` call for this transfer.
+* The recipient contract MAY accept an increase of its balance by returning the acceptance magic value `bytes4(sha256("onCBC1155Received(address,address,uint256,uint256,bytes)"))`
+  * If the return value is `bytes4(sha256("onCBC1155Received(address,address,uint256,uint256,bytes)"))` the transfer MUST be completed or MUST revert if any other conditions are not met for success.
+* The recipient contract MAY reject an increase of its balance by calling revert.
+  * If the recipient contract throws/reverts the transaction MUST be reverted.
+* If the return value is anything other than `bytes4(sha256("onCBC1155Received(address,address,uint256,uint256,bytes)"))` the transaction MUST be reverted.
+* `onCBC1155Received` (and/or `onCBC1155BatchReceived`) MAY be called multiple times in a single transaction and the following requirements must be met:
+  * All callbacks represent mutually exclusive balance changes.
+  * The set of all calls to `onCBC1155Received` and `onCBC1155BatchReceived` describes all balance changes that occurred during the transaction in the order submitted.
+* A contract MAY skip calling the `onCBC1155Received` hook function if the transfer operation is transferring the token to itself.
+
+**_onCBC1155BatchReceived rules:_**
+
+* The `_operator` argument MUST be the address of an account/contract that is approved to make the transfer (SHOULD be msg.sender).
+* The `_from` argument MUST be the address of the holder whose balance is decreased.
+  * `_from` MUST be 0x0 for a mint.
+* The `_ids` argument MUST be the list of tokens being transferred.
+* The `_values` argument MUST be the list of number of tokens (matching the list and order of tokens specified in `_ids`) the holder balance is decreased by and match what the recipient balance is increased by.
+* The `_data` argument MUST contain the information provided by the sender for the transfer with its contents unaltered.
+  * i.e. it MUST pass on the unaltered `_data` argument sent via the `safeBatchTransferFrom` call for this transfer.
+* The recipient contract MAY accept an increase of its balance by returning the acceptance magic value `bytes4(sha256("onCBC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`
+  * If the return value is `bytes4(sha256("onCBC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` the transfer MUST be completed or MUST revert if any other conditions are not met for success.
+* The recipient contract MAY reject an increase of its balance by calling revert.
+  * If the recipient contract throws/reverts the transaction MUST be reverted.
+* If the return value is anything other than `bytes4(sha256("onCBC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` the transaction MUST be reverted.
+* `onCBC1155BatchReceived` (and/or `onCBC1155Received`) MAY be called multiple times in a single transaction and the following requirements must be met:
+  * All callbacks represent mutually exclusive balance changes.
+  * The set of all calls to `onCBC1155Received` and `onCBC1155BatchReceived` describes all balance changes that occurred during the transaction in the order submitted.
+* A contract MAY skip calling the `onCBC1155BatchReceived` hook function if the transfer operation is transferring the token(s) to itself.
+
+**_CBC1155TokenReceiver CBC-165 rules:_**
+
+* The implementation of the CBC-165 `supportsInterface` function SHOULD be as follows:
+
+    ```solidity
+    function supportsInterface(bytes4 interfaceID) external view returns (bool) {
+        return  interfaceID == 0x01ffc9a7 ||    // CBC-165 support (i.e. `bytes4(sha256('supportsInterface(bytes4)'))`).
+                interfaceID == 0x4e2312e0;      // CBC-1155 `CBC1155TokenReceiver` support (i.e. `bytes4(sha256("onCBC1155Received(address,address,uint256,uint256,bytes)")) ^ bytes4(sha256("onCBC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`).
+    }
+    ```
+
+* The implementation MAY differ from the above but:
+  * It MUST return the constant value `true` if `0x01ffc9a7` is passed through the `interfaceID` argument. This signifies CBC-165 support.
+  * It MUST return the constant value `true` if `0x4e2312e0` is passed through the `interfaceID` argument. This signifies CBC-1155 `CBC1155TokenReceiver` support.
+  * It MUST NOT consume more than 10,000 energy.
+    * This keeps it below the CBC-165 requirement of 30,000 energy, reduces the energy reserve needs and minimises possible side-effects of energy exhaustion during the call.
+
+**_Implementation specific transfer API rules:_**
+
+* If an implementation specific API function is used to transfer CBC-1155 token(s) to a contract, the `safeTransferFrom` or `safeBatchTransferFrom` (as appropriate) rules MUST still be followed if the receiver implements the `CBC1155TokenReceiver` interface. If it does not the non-standard implementation SHOULD revert but MAY proceed.
+* An example:
+    1. An approved user calls a function such as `function myTransferFrom(address _from, address _to, uint256[] calldata _ids, uint256[] calldata _values);`.
+    2. `myTransferFrom` updates the balances for `_from` and `_to` addresses for all `_ids` and `_values`.
+    3. `myTransferFrom` emits `TransferBatch` with the details of what was transferred from address `_from` to address `_to`.
+    4. `myTransferFrom` checks if `_to` is a contract address and determines that it is so (if not, then the transfer can be considered successful).
+    5. `myTransferFrom` calls `onCBC1155BatchReceived` on `_to` and it reverts or returns an unknown value (if it had returned `bytes4(sha256("onCBC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))` the transfer can be considered successful).
+    6. At this point `myTransferFrom` SHOULD revert the transaction immediately as receipt of the token(s) was not explicitly accepted by the `onCBC1155BatchReceived` function.
+    7. If however `myTransferFrom` wishes to continue it MUST call `supportsInterface(0x4e2312e0)` on `_to` and if it returns the constant value `true` the transaction MUST be reverted, as it is now known to be a valid receiver and the previous acceptance step failed.
+        * NOTE: You could have called `supportsInterface(0x4e2312e0)` at a previous step if you wanted to gather and act upon that information earlier, such as in a hybrid standards scenario.
+    8. If the above call to `supportsInterface(0x4e2312e0)` on `_to` reverts or returns a value other than the constant value `true` the `myTransferFrom` function MAY consider this transfer successful.
+        * NOTE: this MAY result in unrecoverable tokens if sent to an address that does not expect to receive CBC-1155 tokens.
+* The above example is not exhaustive but illustrates the major points (and shows that most are shared with `safeTransferFrom` and `safeBatchTransferFrom`):
+  * Balances that are updated MUST have equivalent transfer events emitted.
+  * A receiver address has to be checked if it is a contract and if so relevant `CBC1155TokenReceiver` hook function(s) have to be called on it.
+  * Balances (and events associated) that are referenced in a call to an `CBC1155TokenReceiver` hook MUST be updated (and emitted) before the `CBC1155TokenReceiver` hook is called.
+  * The return values of the `CBC1155TokenReceiver` hook functions that are called MUST be respected if they are implemented.
+  * Only non-standard transfer functions MAY allow tokens to be sent to a recipient contract that does NOT implement the necessary `CBC1155TokenReceiver` hook functions. `safeTransferFrom` and `safeBatchTransferFrom` MUST revert in that case (unless it is a hybrid standards implementation see "Backwards Compatibility").
+
+**_Minting/creating and burning/destroying rules:_**
+
+* A mint/create operation is essentially a specialized transfer and MUST follow these rules:
+  * To broadcast the existence of a token ID with no initial balance, the contract SHOULD emit the `TransferSingle` event from `0x0` to `0x0`, with the token creator as `_operator`, and a `_value` of 0.
+  * The "TransferSingle and TransferBatch event rules" MUST be followed as appropriate for the mint(s) (i.e. singles or batches) however the `_from` argument MUST be set to `0x0` (i.e. zero address) to flag the transfer as a mint to contract observers.
+    * NOTE: This includes tokens that are given an initial balance in the contract. The balance of the contract MUST also be able to be determined by events alone meaning initial contract balances (for eg. in construction) MUST emit events to reflect those balances too.
+* A burn/destroy operation is essentially a specialized transfer and MUST follow these rules:
+  * The "TransferSingle and TransferBatch event rules" MUST be followed as appropriate for the burn(s) (i.e. singles or batches) however the `_to` argument MUST be set to `0x0` (i.e. zero address) to flag the transfer as a burn to contract observers.
+  * When burning/destroying you do not have to actually transfer to `0x0` (that is impl specific), only the `_to` argument in the event MUST be set to `0x0` as above.
+* The total value transferred from address `0x0` minus the total value transferred to `0x0` observed via the `TransferSingle` and `TransferBatch` events MAY be used by clients and exchanges to determine the "circulating supply" for a given token ID.
+* As mentioned above mint/create and burn/destroy operations are specialized transfers and so will likely be accomplished with custom transfer functions rather than `safeTransferFrom` or `safeBatchTransferFrom`. If so the "Implementation specific transfer API rules" section would be appropriate.
+  * Even in a non-safe API and/or hybrid standards case the above event rules MUST still be adhered to when minting/creating or burning/destroying.
+* A contract MAY skip calling the `CBC1155TokenReceiver` hook function(s) if the mint operation is transferring the token(s) to itself. In all other cases the `CBC1155TokenReceiver` rules MUST be followed as appropriate for the implementation (i.e. safe, custom and/or hybrid).
+
+##### A solidity example of the sha256 generated constants for the various magic values (these MAY be used by implementation)
+
+```solidity
+bytes4 constant public CBC1155_CBC165 = 0xd9b67a26; // CBC-165 identifier for the main token standard.
+bytes4 constant public CBC1155_CBC165_TOKENRECEIVER = 0x4e2312e0; // CBC-165 identifier for the `CBC1155TokenReceiver` support (i.e. `bytes4(sha256("onCBC1155Received(address,address,uint256,uint256,bytes)")) ^ bytes4(sha256("onCBC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`).
+bytes4 constant public CBC1155_ACCEPTED = 0xf23a6e61; // Return value from `onCBC1155Received` call if a contract accepts receipt (i.e `bytes4(sha256("onCBC1155Received(address,address,uint256,uint256,bytes)"))`).
+bytes4 constant public CBC1155_BATCH_ACCEPTED = 0xbc197c81; // Return value from `onCBC1155BatchReceived` call if a contract accepts receipt (i.e `bytes4(sha256("onCBC1155BatchReceived(address,address,uint256[],uint256[],bytes)"))`).
+```
+
+### Metadata
+
+The URI value allows for ID substitution by clients. If the string `{id}` exists in any URI, clients MUST replace this with the actual token ID in hexadecimal form. This allows for a large number of tokens to use the same on-chain string by defining a URI once, for that large number of tokens.
+
+* The string format of the substituted hexadecimal ID MUST be lowercase alphanumeric: `[0-9a-f]` with no 0x prefix.
+* The string format of the substituted hexadecimal ID MUST be leading zero padded to 64 hex characters length if necessary.
+
+Example of such a URI: `https://token-cdn-domain/{id}.json` would be replaced with `https://token-cdn-domain/000000000000000000000000000000000000000000000000000000000004cce0.json` if the client is referring to token ID 314592/0x4CCE0.
+
+#### Metadata Extensions
+
+The optional `CBC1155Metadata_URI` extension can be identified with the CBC-165 Standard Interface Detection.
+
+If the optional `CBC1155Metadata_URI` extension is included:
+
+* The CBC-165 `supportsInterface` function MUST return the constant value `true` if `0x0e89341c` is passed through the `interfaceID` argument.
+* _Changes_ to the URI MUST emit the `URI` event if the change can be expressed with an event (i.e. it isn't dynamic/programmatic).
+  * An implementation MAY emit the `URI` event during a mint operation but it is NOT mandatory. An observer MAY fetch the metadata uri at mint time from the `uri` function if it was not emitted.
+* The `uri` function SHOULD be used to retrieve values if no event was emitted.
+* The `uri` function MUST return the same value as the latest event for an `_id` if it was emitted.
+* The `uri` function MUST NOT be used to check for the existence of a token as it is possible for an implementation to return a valid string even if the token does not exist.
+
+```solidity
+pragma solidity ^0.5.9;
+
+/**
+    Note: The CBC-165 identifier for this interface is 0x0e89341c.
+*/
+interface CBC1155Metadata_URI {
+    /**
+        @notice A distinct Uniform Resource Identifier (URI) for a given token.
+        @dev URIs are defined in RFC 3986.
+        The URI MUST point to a JSON file that conforms to the "CBC-1155 Metadata URI JSON Schema".
+        @return URI string
+    */
+    function uri(uint256 _id) external view returns (string memory);
+}
+```
+
+#### CBC-1155 Metadata URI JSON Schema
+
+This JSON schema is loosely based on the "CBC721 Metadata JSON Schema", but includes optional formatting to allow for ID substitution by clients. If the string `{id}` exists in any JSON value, it MUST be replaced with the actual token ID, by all client software that follows this standard.
+
+* The string format of the substituted hexadecimal ID MUST be lowercase alphanumeric: `[0-9a-f]` with no 0x prefix.
+* The string format of the substituted hexadecimal ID MUST be leading zero padded to 64 hex characters length if necessary.
+
+```json
+{
+    "title": "Token Metadata",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Identifies the asset to which this token represents"
+        },
+        "decimals": {
+            "type": "integer",
+            "description": "The number of decimal places that the token amount should display - e.g. 18, means to divide the token amount by 1000000000000000000 to get its user representation."
+        },
+        "description": {
+            "type": "string",
+            "description": "Describes the asset to which this token represents"
+        },
+        "image": {
+            "type": "string",
+            "description": "A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
+        },
+        "properties": {
+            "type": "object",
+            "description": "Arbitrary properties. Values may be strings, numbers, object or arrays."
+        }
+    }
+}
+```
+
+An example of an CBC-1155 Metadata JSON file follows. The properties array proposes some SUGGESTED formatting for token-specific display properties and metadata.
+
+```json
+{
+    "name": "Asset Name",
+    "description": "Lorem ipsum...",
+    "image": "https:\/\/s3.amazonaws.com\/your-bucket\/images\/{id}.png",
+    "properties": {
+        "simple_property": "example value",
+        "rich_property": {
+            "name": "Name",
+            "value": "123",
+            "display_value": "123 Example Value",
+            "class": "emphasis",
+            "css": {
+                "color": "#ffffff",
+                "font-weight": "bold",
+                "text-decoration": "underline"
+            }
+        },
+        "array_property": {
+            "name": "Name",
+            "value": [1,2,3,4],
+            "class": "emphasis"
+        }
+    }
+}
+```
+
+##### Localization
+
+Metadata localization should be standardized to increase presentation uniformity across all languages. As such, a simple overlay method is proposed to enable localization. If the metadata JSON file contains a `localization` attribute, its content MAY be used to provide localized values for fields that need it. The `localization` attribute should be a sub-object with three attributes: `uri`, `default` and `locales`. If the string `{locale}` exists in any URI, it MUST be replaced with the chosen locale by all client software.
+
+##### JSON Schema
+
+```json
+{
+    "title": "Token Metadata",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Identifies the asset to which this token represents",
+        },
+        "decimals": {
+            "type": "integer",
+            "description": "The number of decimal places that the token amount should display - e.g. 18, means to divide the token amount by 1000000000000000000 to get its user representation."
+        },
+        "description": {
+            "type": "string",
+            "description": "Describes the asset to which this token represents"
+        },
+        "image": {
+            "type": "string",
+            "description": "A URI pointing to a resource with mime type image/* representing the asset to which this token represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
+        },
+        "properties": {
+            "type": "object",
+            "description": "Arbitrary properties. Values may be strings, numbers, object or arrays.",
+        },
+        "localization": {
+            "type": "object",
+            "required": ["uri", "default", "locales"],
+            "properties": {
+                "uri": {
+                    "type": "string",
+                    "description": "The URI pattern to fetch localized data from. This URI should contain the substring `{locale}` which will be replaced with the appropriate locale value before sending the request."
+                },
+                "default": {
+                    "type": "string",
+                    "description": "The locale of the default data within the base JSON"
+                },
+                "locales": {
+                    "type": "array",
+                    "description": "The list of locales for which data is available. These locales should conform to those defined in the Unicode Common Locale Data Repository (http://cldr.unicode.org/)."
+                }
+            }
+        }
+    }
+}
+```
+
+##### Localized Sample
+
+Base URI:
+
+```json
+{
+  "name": "Advertising Space",
+  "description": "Each token represents a unique Ad space in the city.",
+  "localization": {
+    "uri": "ipfs://QmWS1VAdMD353A6SDk9wNyvkT14kyCiZrNDYAad4w1tKqT/{locale}.json",
+    "default": "en",
+    "locales": ["en", "es", "fr"]
+  }
+}
+```
+
+es.json:
+
+```json
+{
+  "name": "Espacio Publicitario",
+  "description": "Cada token representa un espacio publicitario único en la ciudad."
+}
+```
+
+fr.json:
+
+```json
+{
+  "name": "Espace Publicitaire",
+  "description": "Chaque jeton représente un espace publicitaire unique dans la ville."
+}
+```
+
+### Approval
+
+The function `setApprovalForAll` allows an operator to manage one's entire set of tokens on behalf of the approver. To permit approval of a subset of token IDs, an interface such as CBC-1761 Scoped Approval Interface is suggested.
+The counterpart `isApprovedForAll` provides introspection into any status set by `setApprovalForAll`.
+
+An owner SHOULD be assumed to always be able to operate on their own tokens regardless of approval status, so should SHOULD NOT have to call `setApprovalForAll` to approve themselves as an operator before they can operate on them.
+
+## Rationale
+
+### Metadata Choices
+
+The `symbol` function (found in the CBC-20 and CBC-721 standards) was not included as we do not believe this is a globally useful piece of data to identify a generic virtual item / asset and are also prone to collisions. Short-hand symbols are used in tickers and currency trading, but they aren't as useful outside of that space.
+
+The `name` function (for human-readable asset names, on-chain) was removed from the standard to allow the Metadata JSON to be the definitive asset name and reduce duplication of data. This also allows localization for names, which would otherwise be prohibitively expensive if each language string was stored on-chain, not to mention bloating the standard interface. While this decision may add a small burden on implementers to host a JSON file containing metadata, we believe any serious implementation of CBC-1155 will already utilize JSON Metadata.
+
+### Upgrades
+
+The requirement to emit `TransferSingle` or `TransferBatch` on balance change implies that a valid implementation of CBC-1155 redeploying to a new contract address MUST emit events from the new contract address to replicate the deprecated contract final state. It is valid to only emit a minimal number of events to reflect only the final balance and omit all the transactions that led to that state. The event emit requirement is to ensure that the current state of the contract can always be traced only through events. To alleviate the need to emit events when changing contract address, consider using the proxy pattern, such as described in CIP-2535. This will also have the added benefit of providing a stable contract address for users.
+
+### Design decision: Supporting non-batch
+
+The standard supports `safeTransferFrom` and `onCBC1155Received` functions because they are significantly cheaper for single token-type transfers, which is arguably a common use case.
+
+### Design decision: Safe transfers only
+
+The standard only supports safe-style transfers, making it possible for receiver contracts to depend on `onCBC1155Received` or `onCBC1155BatchReceived` function to be always called at the end of a transfer.
+
+### Guaranteed log trace
+
+As the Ethereum ecosystem continues to grow, many dapps are relying on traditional databases and explorer API services to retrieve and categorize data. The CBC-1155 standard guarantees that event logs emitted by the smart contract will provide enough data to create an accurate record of all current token balances. A database or explorer may listen to events and be able to provide indexed and categorized searches of every CBC-1155 token in the contract.
+
+### Approver
+
+The function `setApprovalForAll` allows an operator to manage one's entire set of tokens on behalf of the approver. It enables frictionless interaction with exchange and trade contracts.
+
+Restricting approval to a certain set of token IDs, quantities or other rules MAY be done with an additional interface or an external contract. The rationale is to keep the CBC-1155 standard as generic as possible for all use-cases without imposing a specific approval scheme on implementations that may not need it. Standard token approval interfaces can be used, such as the suggested CBC-1761 Scoped Approval Interface which is compatible with CBC-1155.
+
+## Backwards Compatibility
+
+There have been requirements during the design discussions to have this standard be compatible with existing standards when sending to contract addresses, specifically CBC-721 at time of writing.
+To cater for this scenario, there is some leeway with the revert logic should a contract not implement the `CBC1155TokenReceiver` as per "Safe Transfer Rules" section above, specifically "Scenario#3 : The receiver does not implement the necessary `CBC1155TokenReceiver` interface function(s)".
+
+Hence in a hybrid CBC-1155 contract implementation an extra call MUST be made on the recipient contract and checked before any hook calls to `onCBC1155Received` or `onCBC1155BatchReceived` are made.
+Order of operation MUST therefore be:
+
+1. The implementation MUST call the function `supportsInterface(0x4e2312e0)` on the recipient contract, providing at least 10,000 energy.
+2. If the function call succeeds and the return value is the constant value `true` the implementation proceeds as a regular CBC-1155 implementation, with the call(s) to the `onCBC1155Received` or `onCBC1155BatchReceived` hooks and rules associated.
+3. If the function call fails or the return value is NOT the constant value `true` the implementation can assume the recipient contract is not an `CBC1155TokenReceiver` and follow its other standard's rules for transfers.
+Note that a pure implementation of a single standard is recommended rather than a hybrid solution, but an example of a hybrid CBC-1155/CBC-721 contract is linked in the references section under implementations.
+
+An important consideration is that even if the tokens are sent with another standard's rules the CBC-1155 transfer events MUST still be emitted. This is so the balances can still be determined via events alone as per CBC-1155 standard rules.
+
+## Usage
+
+This standard can be used to represent multiple token types for an entire domain. Both fungible and non-fungible tokens can be stored in the same smart-contract.
+
+### Batch Transfers
+
+The `safeBatchTransferFrom` function allows for batch transfers of multiple token IDs and values. The design of CBC-1155 makes batch transfers possible without the need for a wrapper contract, as with existing token standards. This reduces energy costs when more than one token type is included in a batch transfer, as compared to single transfers with multiple transactions.
+
+Another advantage of standardized batch transfers is the ability for a smart contract to respond to the batch transfer in a single operation using `onCBC1155BatchReceived`.
+
+It is RECOMMENDED that clients and wallets sort the token IDs and associated values (in ascending order) when posting a batch transfer, as some CBC-1155 implementations offer significant energy cost savings when IDs are sorted.
+
+### Batch Balance
+
+The `balanceOfBatch` function allows clients to retrieve balances of multiple owners and token IDs with a single call.
+
+### Enumerating from events
+
+In order to keep storage requirements light for contracts implementing CBC-1155, enumeration (discovering the IDs and values of tokens) must be done using event logs. It is RECOMMENDED that clients such as exchanges and blockchain explorers maintain a local database containing the token ID, Supply, and URI at the minimum. This can be built from each TransferSingle, TransferBatch, and URI event, starting from the block the smart contract was deployed until the latest block.
+
+CBC-1155 contracts must therefore carefully emit `TransferSingle` or `TransferBatch` events in any instance where tokens are created, minted, transferred or destroyed.
+
+### Non-Fungible Tokens
+
+The following strategies are examples of how you MAY mix fungible and non-fungible tokens together in the same contract. The standard does NOT mandate how an implementation must do this.
+
+#### Split ID bits
+
+The top 128 bits of the uint256 `_id` parameter in any CBC-1155 function MAY represent the base token ID, while the bottom 128 bits MAY represent the index of the non-fungible to make it unique.
+
+Non-fungible tokens can be interacted with using an index based accessor into the contract/token data set. Therefore to access a particular token set within a mixed data contract and a particular non-fungible within that set, `_id` could be passed as `<uint128: base token id><uint128: index of non-fungible>`.
+
+To identify a non-fungible set/category as a whole (or a fungible) you COULD just pass in the base id via the `_id` argument as `<uint128: base token id><uint128: zero>`. If your implementation uses this technique this naturally means the index of a non-fungible SHOULD be 1-based.
+
+Inside the contract code the two pieces of data needed to access the individual non-fungible can be extracted with uint128(~0) and the same mask shifted by 128.
+
+```solidity
+uint256 baseTokenNFT = 12345 << 128;
+uint128 indexNFT = 50;
+
+uint256 baseTokenFT = 54321 << 128;
+
+balanceOf(msg.sender, baseTokenNFT); // Get balance of the base token for non-fungible set 12345 (this MAY be used to get balance of the user for all of this token set if the implementation wishes as a convenience).
+balanceOf(msg.sender, baseTokenNFT + indexNFT); // Get balance of the token at index 50 for non-fungible set 12345 (should be 1 if user owns the individual non-fungible token or 0 if they do not).
+balanceOf(msg.sender, baseTokenFT); // Get balance of the fungible base token 54321.
+```
+
+Note that 128 is an arbitrary number, an implementation MAY choose how they would like this split to occur as suitable for their use case. An observer of the contract would simply see events showing balance transfers and mints happening and MAY track the balances using that information alone.
+For an observer to be able to determine type (non-fungible or fungible) from an ID alone they would have to know the split ID bits format on a implementation by implementation basis.
+
+##### Natural Non-Fungible tokens
+
+Another simple way to represent non-fungibles is to allow a maximum value of 1 for each non-fungible token. This would naturally mirror the real world, where unique items have a quantity of 1 and fungible items have a quantity greater than 1.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cip/cbc/cip-150.md
+++ b/cip/cbc/cip-150.md
@@ -1,6 +1,6 @@
 ---
 cip: 150
-title: On-Chain Key-Value Metadata Storage for Compact Descriptors
+title: RWA Metadata Storage
 description: >-
   A standardized smart contract interface for storing compact key-value metadata
   on-chain with support for sealed and unsealed entries.
@@ -19,7 +19,7 @@ tags:
 date: 2025-07-01T00:00:00.000Z
 ---
 
-On-Chain Key-Value Metadata Storage for Compact Descriptors
+On-Chain Key-Value Metadata Storage for Compact Descriptors.
 
 <!--truncate-->
 
@@ -162,8 +162,8 @@ The following table lists each month and its corresponding month code as referen
 
 | Method                | Scope       | Location  | Mutable  | Standard Use                      |
 | --------------------- | ----------- | --------- | -------- | --------------------------------- |
-| `name()` / `symbol()` | Global      | On-chain  | No       | Identification (ERC-20/4626)      |
-| `tokenURI()`          | Per-token   | Off-chain | Yes      | NFT metadata (ERC-721/1155)       |
+| `name()` / `symbol()` | Global      | On-chain  | No       | Identification (CBC-20/4626)      |
+| `tokenURI()`          | Per-token   | Off-chain | Yes      | NFT metadata (CBC-721/1155)       |
 | **KV (this CIP)**     | Key-defined | On-chain  | Optional | Contextual metadata, docs, hashes |
 
 ## Rationale
@@ -172,12 +172,12 @@ The on-chain key-value metadata storage approach addresses the need for flexible
 
 ## Backward Compatibility
 
-This standard is designed to work alongside existing metadata approaches like ERC-20 name/symbol functions and ERC-721 tokenURI, providing additional flexibility without breaking existing implementations.
+This standard is designed to work alongside existing metadata approaches like CBC-20 name/symbol functions and CBC-721 tokenURI, providing additional flexibility without breaking existing implementations.
 
 ## Security Considerations
 
 - Mutable entries must be explicitly managed and sealed once final.
-- Gas efficiency must be considered for large-scale use.
+- Energy efficiency must be considered for large-scale use.
 - Contracts should restrict `setValue()` and `sealKey()` to authorized parties.
 - Consider using versioned keys (e.g. `PROSPECTUS_V1`, `PROSPECTUS_V2`) to retain history.
 

--- a/cip/cbc/cip-151.md
+++ b/cip/cbc/cip-151.md
@@ -108,7 +108,7 @@ If `tokenExpiration` is not set, transfers should proceed as normal.
 This metadata format is compatible with:
 
 - CIP-KV-Metadata standard (on-chain key-value)
-- ERC-20 and ERC-721 smart contracts
+- CBC-20 and CBC-721 smart contracts
 - EVM and non-EVM chains using Unix timestamp logic
 
 ## Security Considerations

--- a/cip/cbc/cip-165.md
+++ b/cip/cbc/cip-165.md
@@ -73,14 +73,14 @@ interface CIP165 {
     /// @notice Query if a contract implements an interface
     /// @param interfaceID The interface identifier, as specified in CIP-165
     /// @dev Interface identification is specified in CIP-165. This function
-    ///  uses less than 30,000 gas.
+    ///  uses less than 30,000 energy.
     /// @return `true` if the contract implements `interfaceID` and
     ///  `interfaceID` is not 0xffffffff, `false` otherwise
     function supportsInterface(bytes4 interfaceID) external view returns (bool);
 }
 ```
 
-The interface identifier for this interface is `0x01ffc9a7`. You can calculate this by running `bytes4(keccak256('supportsInterface(bytes4)'));` or using the `Selector` contract above.
+The interface identifier for this interface is `0x01ffc9a7`. You can calculate this by running `bytes4(sha256('supportsInterface(bytes4)'));` or using the `Selector` contract above.
 
 Therefore the implementing contract will have a `supportsInterface` function that returns:
 
@@ -89,13 +89,13 @@ Therefore the implementing contract will have a `supportsInterface` function tha
 - `true` for any other `interfaceID` this contract implements
 - `false` for any other `interfaceID`
 
-This function must return a bool and use at most 30,000 gas.
+This function must return a bool and use at most 30,000 energy.
 
-Implementation note, there are several logical ways to implement this function. Please see the example implementations and the discussion on gas usage.
+Implementation note, there are several logical ways to implement this function. Please see the example implementations and the discussion on energy usage.
 
 ### How to Detect if a Contract Implements CIP-165
 
-1. The source contract makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a700000000000000000000000000000000000000000000000000000000` and gas 30,000. This corresponds to `contract.supportsInterface(0x01ffc9a7)`.
+1. The source contract makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a700000000000000000000000000000000000000000000000000000000` and energy 30,000. This corresponds to `contract.supportsInterface(0x01ffc9a7)`.
 2. If the call fails or return false, the destination contract does not implement CIP-165.
 3. If the call returns true, a second call is made with input data `0x01ffc9a7ffffffff00000000000000000000000000000000000000000000000000000000`.
 4. If the second call fails or returns true, the destination contract does not implement CIP-165.
@@ -156,7 +156,7 @@ contract CIP165Query {
                 mstore(add(x, 0x04), _interfaceId) // Place first argument directly next to signature
 
                 success := staticcall(
-                                    30000,         // 30k gas
+                                    30000,         // 30k energy
                                     _contract,     // To addr
                                     x,             // Inputs are stored at location x
                                     0x24,          // Inputs are 36 bytes long
@@ -171,7 +171,7 @@ contract CIP165Query {
 
 ## Implementation
 
-This approach uses a `view` function implementation of `supportsInterface`. The execution cost is 586 gas for any input. But contract initialization requires storing each interface (`SSTORE` is 20,000 gas). The `CIP165MappingImplementation` contract is generic and reusable.
+This approach uses a `view` function implementation of `supportsInterface`. The execution cost is 586 energy for any input. But contract initialization requires storing each interface (`SSTORE` is 20,000 energy). The `CIP165MappingImplementation` contract is generic and reusable.
 
 ```solidity
 pragma solidity ^0.8.0;
@@ -206,7 +206,7 @@ contract Lisa is CIP165MappingImplementation, Simpson {
 }
 ```
 
-Following is a `pure` function implementation of `supportsInterface`. The worst-case execution cost is 236 gas, but increases linearly with a higher number of supported interfaces.
+Following is a `pure` function implementation of `supportsInterface`. The worst-case execution cost is 236 energy, but increases linearly with a higher number of supported interfaces.
 
 ```solidity
 pragma solidity ^0.8.0;
@@ -231,12 +231,12 @@ contract Homer is CIP165, Simpson {
 }
 ```
 
-With three or more supported interfaces (including CIP-165 itself as a required supported interface), the mapping approach (in every case) costs less gas than the pure approach (at worst case).
+With three or more supported interfaces (including CIP-165 itself as a required supported interface), the mapping approach (in every case) costs less energy than the pure approach (at worst case).
 
 ## Security Considerations
 
 - Ensure proper validation of interface IDs to prevent malicious contracts from claiming to implement interfaces they don't support
-- Consider gas costs when implementing interface detection in frequently called functions
+- Consider energy costs when implementing interface detection in frequently called functions
 - Validate that the `0xffffffff` interface ID is never set to true in mapping implementations
 
 ## Conclusion

--- a/cip/cbc/cip-1761.md
+++ b/cip/cbc/cip-1761.md
@@ -1,0 +1,138 @@
+---
+cip: 1761
+title: Scoped Approval Interface
+description: >-
+  A standardized smart contract interface for restricted (scoped) approval of token IDs, enabling fine-grained operator permissions for CBC-1155, CBC-721, and similar token contracts.
+keywords:
+  - cip
+  - cip-1761
+  - cbc
+  - approval
+  - scope
+  - operator
+  - access control
+  - multi-token
+  - standard
+author: Rastislav Vašička <rastislav@onion.email>
+lang: en-US
+status: draft
+tags:
+  - cbc
+date: 2025-07-06T00:00:00.000Z
+requires:
+  - cip-165
+---
+
+A standardized smart contract interface for restricted (scoped) approval of token IDs, enabling fine-grained operator permissions for CBC-1155, CBC-721, and similar token contracts.
+
+<!--truncate-->
+
+## Abstract
+
+This standard defines a common interface for restricted (scoped) approval in token contracts with an "ID" domain, such as CBC-1155 or CBC-721. CBC-1761 enables fine-grained operator permissions by defining "scopes" of one or more token IDs, allowing users to grant or revoke operator rights for specific groups of tokens. This improves security and flexibility for asset management, gaming, and enterprise use cases.
+
+## Motivation
+
+Traditional approval mechanisms in CBC-1155 and CBC-721 allow operators to manage all of a user's tokens, which can lead to excessive risk if the operator is compromised. CBC-1761 introduces the concept of scopes, enabling users to restrict operator permissions to specific token groups or domains. This reduces risk and enables new use cases, such as regional asset management, game developer collaboration, and differentiated access for high- and low-value tokens.
+
+## Specification
+
+### Interface
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * Note: The CBC-165 identifier for this interface is 0x30168307.
+ */
+interface ICBC1761 {
+    // --- Events ---
+    event ApprovalForScope(address indexed owner, address indexed operator, bytes32 indexed scope, bool approved);
+    event IdsAddedToScope(uint256 indexed idStart, uint256 indexed idEnd, bytes32 indexed scope);
+    event IdsRemovedFromScope(uint256 indexed idStart, uint256 indexed idEnd, bytes32 indexed scope);
+    event ScopeURI(string value, bytes32 indexed scope);
+
+    // --- Core Functions ---
+    function scopeCountForId(uint256 id) external view returns (uint32);
+    function scopeForId(uint256 id, uint32 scopeIndex) external view returns (bytes32);
+    function scopeUri(bytes32 scope) external view returns (string memory);
+    function setApprovalForScope(address operator, bytes32 scope, bool approved) external;
+    function isApprovedForScope(address owner, address operator, bytes32 scope) external view returns (bool);
+}
+```
+
+### Scope Metadata JSON Schema
+
+This schema allows for localization and human-readable scope metadata.
+
+```json
+{
+  "title": "Scope Metadata",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Identifies the scope in a human-readable way."
+    },
+    "description": {
+      "type": "string",
+      "description": "Describes the scope to allow users to make informed approval decisions."
+    },
+    "localization": {
+      "type": "object",
+      "required": ["uri", "default", "locales"],
+      "properties": {
+        "uri": {
+          "type": "string",
+          "description": "The URI pattern to fetch localized data from. This URI should contain the substring {locale}."
+        },
+        "default": {
+          "type": "string",
+          "description": "The locale of the default data within the base JSON."
+        },
+        "locales": {
+          "type": "array",
+          "description": "The list of locales for which data is available."
+        }
+      }
+    }
+  }
+}
+```
+
+### Method Behaviors
+
+- Implementations MAY define a fixed or dynamic set of scopes.
+- Scopes can be used to group token IDs by region, type, or any custom logic.
+- The `setApprovalForScope` function MUST emit the `ApprovalForScope` event.
+- Adding or removing IDs from a scope MUST emit the corresponding events.
+- The `scopeUri` function SHOULD return a valid URI for scope metadata, or an empty string if not available.
+
+### Localization
+
+Metadata localization should be standardized to increase presentation uniformity across all languages. As such, a simple overlay method is proposed to enable localization. If the metadata JSON file contains a `localization` attribute, its content may be used to provide localized values for fields that need it. The `localization` attribute should be a sub-object with three attributes: `uri`, `default` and `locales`. If the string `{locale}` exists in any URI, it MUST be replaced with the chosen locale by all client software.
+
+## Rationale
+
+CBC-1761 generalizes approval mechanisms for multi-token contracts, enabling safer and more flexible operator permissions. By supporting scopes, users can delegate control over specific assets without exposing their entire portfolio, and developers can build more granular access control systems for games, enterprises, and asset platforms.
+
+### Metadata JSON
+
+The Scope Metadata JSON Schema was added in order to support human-readable scope names and descriptions in more than one language.
+
+## Security Considerations
+
+- Implementers must ensure that scope assignment and approval logic is correct and cannot be bypassed.
+- Scopes should be clearly defined and documented to avoid user confusion.
+- Metadata URIs should be immutable or versioned to prevent tampering.
+- Access control and upgradability best practices should be followed.
+
+## References
+
+- [JSON Schema](https://json-schema.org/)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cip/cbc/cip-1820.md
+++ b/cip/cbc/cip-1820.md
@@ -1,0 +1,834 @@
+---
+cip: 1820
+title: Pseudo-introspection Registry Contract
+description: >-
+  A universal registry smart contract where any address (contract or regular account) can register which interface it supports and which smart contract is responsible for its implementation. This standard keeps backward compatibility with CBC-165.
+keywords:
+  - cip
+  - cip-1820
+  - cbc
+  - registry
+  - interface
+  - introspection
+  - standard
+  - smart contract
+author: Rastislav Vašička <rastislav@onion.email>
+lang: en-US
+status: final
+tags:
+  - cbc
+date: 2025-07-06T00:00:00.000Z
+requires:
+  - cip-165
+  - cip-214
+---
+
+A universal registry smart contract where any address (contract or regular account) can register which interface it supports and which smart contract is responsible for its implementation. This standard keeps backward compatibility with CBC-165.
+
+<!--truncate-->
+
+## Abstract
+
+This standard defines a registry where smart contracts and regular accounts can publish which functionality they implement---either directly or through a proxy contract.
+
+Anyone can query this registry to ask if a specific address implements a given interface and which smart contract handles its implementation.
+
+This registry MAY be deployed on any chain and shares the same address on all chains.
+
+Interfaces with zeroes (`0`) as the last 28 bytes are considered CBC-165 interfaces,
+and this registry SHALL forward the call to the contract to see if it implements the interface.
+
+This contract also acts as an CBC-165 cache to reduce energy consumption.
+
+## Motivation
+
+There have been different approaches to define pseudo-introspection in Ethereum.
+The first is CBC-165 which has the limitation that it cannot be used by regular accounts.
+The second attempt is CBC-672 which uses reverse ENS. Using reverse ENS has two issues.
+First, it is unnecessarily complicated, and second, ENS is still a centralized contract controlled by a multisig.
+This multisig theoretically would be able to modify the system.
+
+This standard is much simpler than CBC-672, and it is *fully* decentralized.
+
+This standard also provides a *unique* address for all chains.
+Thus solving the problem of resolving the correct registry address for different chains.
+
+## Specification
+
+### CBC-1820 Registry Smart Contract
+
+> This is an exact copy of the code of the CBC-1820 registry smart contract.
+
+``` solidity
+/* CBC1820 Pseudo-introspection Registry Contract
+ * This standard defines a universal registry smart contract where any address (contract or regular account) can
+ * register which interface it supports and which smart contract is responsible for its implementation.
+ *
+ * Written in 2019 by Jordi Baylina and Jacques Dafflon
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to
+ * this software to the public domain worldwide. This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software. If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ *
+ *    ███████╗██████╗  ██████╗ ██╗ █████╗ ██████╗  ██████╗
+ *    ██╔════╝██╔══██╗██╔════╝███║██╔══██╗╚════██╗██╔═████╗
+ *    █████╗  ██████╔╝██║     ╚██║╚█████╔╝ █████╔╝██║██╔██║
+ *    ██╔══╝  ██╔══██╗██║      ██║██╔══██╗██╔═══╝ ████╔╝██║
+ *    ███████╗██║  ██║╚██████╗ ██║╚█████╔╝███████╗╚██████╔╝
+ *    ╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚═╝ ╚════╝ ╚══════╝ ╚═════╝
+ *
+ *    ██████╗ ███████╗ ██████╗ ██╗███████╗████████╗██████╗ ██╗   ██╗
+ *    ██╔══██╗██╔════╝██╔════╝ ██║██╔════╝╚══██╔══╝██╔══██╗╚██╗ ██╔╝
+ *    ██████╔╝█████╗  ██║  ███╗██║███████╗   ██║   ██████╔╝ ╚████╔╝
+ *    ██╔══██╗██╔══╝  ██║   ██║██║╚════██║   ██║   ██╔══██╗  ╚██╔╝
+ *    ██║  ██║███████╗╚██████╔╝██║███████║   ██║   ██║  ██║   ██║
+ *    ╚═╝  ╚═╝╚══════╝ ╚═════╝ ╚═╝╚══════╝   ╚═╝   ╚═╝  ╚═╝   ╚═╝
+ *
+ */
+pragma solidity 0.5.3;
+// IV is value needed to have a vanity address starting with '0x1820'.
+// IV: 53759
+
+/// @dev The interface a contract MUST implement if it is the implementer of
+/// some (other) interface for any address other than itself.
+interface CBC1820ImplementerInterface {
+    /// @notice Indicates whether the contract implements the interface 'interfaceHash' for the address 'addr' or not.
+    /// @param interfaceHash sha256 hash of the name of the interface
+    /// @param addr Address for which the contract will implement the interface
+    /// @return CBC1820_ACCEPT_MAGIC only if the contract implements 'interfaceHash' for the address 'addr'.
+    function canImplementInterfaceForAddress(bytes32 interfaceHash, address addr) external view returns(bytes32);
+}
+
+
+/// @title CBC1820 Pseudo-introspection Registry Contract
+/// @author Jordi Baylina and Jacques Dafflon
+/// @notice This contract is the official implementation of the CBC1820 Registry.
+contract CBC1820Registry {
+    /// @notice CBC165 Invalid ID.
+    bytes4 constant internal INVALID_ID = 0xffffffff;
+    /// @notice Method ID for the CBC165 supportsInterface method (= `bytes4(sha256('supportsInterface(bytes4)'))`).
+    bytes4 constant internal CBC165ID = 0x01ffc9a7;
+    /// @notice Magic value which is returned if a contract implements an interface on behalf of some other address.
+    bytes32 constant internal CBC1820_ACCEPT_MAGIC = sha256(abi.encodePacked("CBC1820_ACCEPT_MAGIC"));
+
+    /// @notice mapping from addresses and interface hashes to their implementers.
+    mapping(address => mapping(bytes32 => address)) internal interfaces;
+    /// @notice mapping from addresses to their manager.
+    mapping(address => address) internal managers;
+    /// @notice flag for each address and CBC165 interface to indicate if it is cached.
+    mapping(address => mapping(bytes4 => bool)) internal CBC165Cached;
+
+    /// @notice Indicates a contract is the 'implementer' of 'interfaceHash' for 'addr'.
+    event InterfaceImplementerSet(address indexed addr, bytes32 indexed interfaceHash, address indexed implementer);
+    /// @notice Indicates 'newManager' is the address of the new manager for 'addr'.
+    event ManagCBChanged(address indexed addr, address indexed newManager);
+
+    /// @notice Query if an address implements an interface and through which contract.
+    /// @param _addr Address being queried for the implementer of an interface.
+    /// (If '_addr' is the zero address then 'msg.sender' is assumed.)
+    /// @param _interfaceHash Sha256 hash of the name of the interface as a string.
+    /// E.g., 'web3.utils.sha256("CBC777TokensRecipient")' for the 'CBC777TokensRecipient' interface.
+    /// @return The address of the contract which implements the interface '_interfaceHash' for '_addr'
+    /// or '0' if '_addr' did not register an implementer for this interface.
+    function getInterfaceImplementer(address _addr, bytes32 _interfaceHash) external view returns (address) {
+        address addr = _addr == address(0) ? msg.sender : _addr;
+        if (isCBC165Interface(_interfaceHash)) {
+            bytes4 CBC165InterfaceHash = bytes4(_interfaceHash);
+            return implementsCBC165Interface(addr, cbc165InterfaceHash) ? addr : address(0);
+        }
+        return interfaces[addr][_interfaceHash];
+    }
+
+    /// @notice Sets the contract which implements a specific interface for an address.
+    /// Only the manager defined for that address can set it.
+    /// (Each address is the manager for itself until it sets a new manager.)
+    /// @param _addr Address for which to set the interface.
+    /// (If '_addr' is the zero address then 'msg.sender' is assumed.)
+    /// @param _interfaceHash Sha256 hash of the name of the interface as a string.
+    /// E.g., 'web3.utils.sha256("CBC777TokensRecipient")' for the 'CBC777TokensRecipient' interface.
+    /// @param _implementer Contract address implementing '_interfaceHash' for '_addr'.
+    function setInterfaceImplementer(address _addr, bytes32 _interfaceHash, address _implementer) external {
+        address addr = _addr == address(0) ? msg.sender : _addr;
+        require(getManager(addr) == msg.sender, "Not the manager");
+
+        require(!isCBC165Interface(_interfaceHash), "Must not be an CBC165 hash");
+        if (_implementer != address(0) && _implementer != msg.sender) {
+            require(
+                CBC1820ImplementerInterface(_implementer)
+                    .canImplementInterfaceForAddress(_interfaceHash, addr) == CBC1820_ACCEPT_MAGIC,
+                "Does not implement the interface"
+            );
+        }
+        interfaces[addr][_interfaceHash] = _implementer;
+        emit InterfaceImplementerSet(addr, _interfaceHash, _implementer);
+    }
+
+    /// @notice Sets '_newManager' as manager for '_addr'.
+    /// The new manager will be able to call 'setInterfaceImplementer' for '_addr'.
+    /// @param _addr Address for which to set the new manager.
+    /// @param _newManager Address of the new manager for 'addr'. (Pass '0x0' to reset the manager to '_addr'.)
+    function setManager(address _addr, address _newManager) external {
+        require(getManager(_addr) == msg.sender, "Not the manager");
+        managers[_addr] = _newManager == _addr ? address(0) : _newManager;
+        emit ManagerChanged(_addr, _newManager);
+    }
+
+    /// @notice Get the manager of an address.
+    /// @param _addr Address for which to return the manager.
+    /// @return Address of the manager for a given address.
+    function getManager(address _addr) public view returns(address) {
+        // By default the manager of an address is the same address
+        if (managers[_addr] == address(0)) {
+            return _addr;
+        } else {
+            return managers[_addr];
+        }
+    }
+
+    /// @notice Compute the sha256 hash of an interface given its name.
+    /// @param _interfaceName Name of the interface.
+    /// @return The sha256 hash of an interface name.
+    function interfaceHash(string calldata _interfaceName) external pure returns(bytes32) {
+        return sha256(abi.encodePacked(_interfaceName));
+    }
+
+    /* --- CBC165 Related Functions --- */
+    /* --- Developed in collaboration with William Entriken. --- */
+
+    /// @notice Updates the cache with whether the contract implements an CBC165 interface or not.
+    /// @param _contract Address of the contract for which to update the cache.
+    /// @param _interfaceId CBC165 interface for which to update the cache.
+    function updateCBC165Cache(address _contract, bytes4 _interfaceId) external {
+        interfaces[_contract][_interfaceId] = implementsCBC165InterfaceNoCache(
+            _contract, _interfaceId) ? _contract : address(0);
+        cbc165Cached[_contract][_interfaceId] = true;
+    }
+
+    /// @notice Checks whether a contract implements an CBC165 interface or not.
+    //  If the result is not cached a direct lookup on the contract address is performed.
+    //  If the result is not cached or the cached value is out-of-date, the cache MUST be updated manually by calling
+    //  'updateCBC165Cache' with the contract address.
+    /// @param _contract Address of the contract to check.
+    /// @param _interfaceId CBC165 interface to check.
+    /// @return True if '_contract' implements '_interfaceId', false otherwise.
+    function implementsCBC165Interface(address _contract, bytes4 _interfaceId) public view returns (bool) {
+        if (!cbc165Cached[_contract][_interfaceId]) {
+            return implementsCBC165InterfaceNoCache(_contract, _interfaceId);
+        }
+        return interfaces[_contract][_interfaceId] == _contract;
+    }
+
+    /// @notice Checks whether a contract implements an CBC165 interface or not without using nor updating the cache.
+    /// @param _contract Address of the contract to check.
+    /// @param _interfaceId CBC165 interface to check.
+    /// @return True if '_contract' implements '_interfaceId', false otherwise.
+    function implementsCBC165InterfaceNoCache(address _contract, bytes4 _interfaceId) public view returns (bool) {
+        uint256 success;
+        uint256 result;
+
+        (success, result) = noThrowCall(_contract, CBC165ID);
+        if (success == 0 || result == 0) {
+            return false;
+        }
+
+        (success, result) = noThrowCall(_contract, INVALID_ID);
+        if (success == 0 || result != 0) {
+            return false;
+        }
+
+        (success, result) = noThrowCall(_contract, _interfaceId);
+        if (success == 1 && result == 1) {
+            return true;
+        }
+        return false;
+    }
+
+    /// @notice Checks whether the hash is a CBC165 interface (ending with 28 zeroes) or not.
+    /// @param _interfaceHash The hash to check.
+    /// @return True if '_interfaceHash' is an CBC165 interface (ending with 28 zeroes), false otherwise.
+    function isCBC165Interface(bytes32 _interfaceHash) internal pure returns (bool) {
+        return _interfaceHash & 0x00000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF == 0;
+    }
+
+    /// @dev Make a call on a contract without throwing if the function does not exist.
+    function noThrowCall(address _contract, bytes4 _interfaceId)
+        internal view returns (uint256 success, uint256 result)
+    {
+        bytes4 cbc165ID = CBC165ID;
+
+        assembly {
+            let x := mload(0x40)               // Find empty storage location using "free memory pointer"
+            mstore(x, cbc165ID)                // Place signature at beginning of empty storage
+            mstore(add(x, 0x04), _interfaceId) // Place first argument directly next to signature
+
+            success := staticcall(
+                30000,                         // 30k energy
+                _contract,                     // To addr
+                x,                             // Inputs are stored at location x
+                0x24,                          // Inputs are 36 (4 + 32) bytes long
+                x,                             // Store output over input (saves space)
+                0x20                           // Outputs are 32 bytes long
+            )
+
+            result := mload(x)                 // Load the result
+        }
+    }
+}
+
+```
+
+### Deployment Method
+
+This contract is going to be deployed using the keyless deployment method - also known as Nick's method - which relies on a single-use address.
+(See Nick's article for more details). This method works as follows:
+
+1. Generate a transaction which deploys the contract from a new random account.
+   - This transaction MUST NOT use CIP-155 in order to work on any chain.
+   - This transaction MUST have a relatively high energy price to be deployed on any chain. In this case, it is going to be 100 Gwei.
+2. Set the `v`, `r`, `s` of the transaction signature
+3. We recover the sender of this transaction, i.e., the single-use deployment account.
+    > Thus we obtain an account that can broadcast that transaction, but we also have the warranty that nobody knows the private key of that account.
+4. Send exactly 0.08 ether to this single-use deployment account.
+5. Broadcast the deployment transaction.
+
+This operation can be done on any chain, guaranteeing that the contract address is always the same and nobody can use that address with a different contract.
+
+### Single-use Registry Deployment Account
+
+This account is generated by reverse engineering it from its signature for the transaction.
+This way no one knows the private key, but it is known that it is the valid signer of the deployment transaction.
+
+> To deploy the registry, 0.08 ether MUST be sent to this account *first*.
+
+### Registry Contract Address
+
+The contract has the address above for every chain on which it is deployed.
+
+Raw metadata of `./contracts/CBC1820Registry.sol`
+
+```json
+{
+        "compiler": {
+          "version": "0.5.3+commit.10d17f24"
+        },
+        "language": "Solidity",
+        "output": {
+          "abi": [
+            {
+              "constant": false,
+              "inputs": [
+                {
+                  "name": "_addr",
+                  "type": "address"
+                },
+                {
+                  "name": "_interfaceHash",
+                  "type": "bytes32"
+                },
+                {
+                  "name": "_implementer",
+                  "type": "address"
+                }
+              ],
+              "name": "setInterfaceImplementer",
+              "outputs": [],
+              "payable": false,
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "constant": true,
+              "inputs": [
+                {
+                  "name": "_addr",
+                  "type": "address"
+                }
+              ],
+              "name": "getManager",
+              "outputs": [
+                {
+                  "name": "",
+                  "type": "address"
+                }
+              ],
+              "payable": false,
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "constant": false,
+              "inputs": [
+                {
+                  "name": "_addr",
+                  "type": "address"
+                },
+                {
+                  "name": "_newManager",
+                  "type": "address"
+                }
+              ],
+              "name": "setManager",
+              "outputs": [],
+              "payable": false,
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "constant": true,
+              "inputs": [
+                {
+                  "name": "_interfaceName",
+                  "type": "string"
+                }
+              ],
+              "name": "interfaceHash",
+              "outputs": [
+                {
+                  "name": "",
+                  "type": "bytes32"
+                }
+              ],
+              "payable": false,
+              "stateMutability": "pure",
+              "type": "function"
+            },
+            {
+              "constant": false,
+              "inputs": [
+                {
+                  "name": "_contract",
+                  "type": "address"
+                },
+                {
+                  "name": "_interfaceId",
+                  "type": "bytes4"
+                }
+              ],
+              "name": "updateCBC165Cache",
+              "outputs": [],
+              "payable": false,
+              "stateMutability": "nonpayable",
+              "type": "function"
+            },
+            {
+              "constant": true,
+              "inputs": [
+                {
+                  "name": "_addr",
+                  "type": "address"
+                },
+                {
+                  "name": "_interfaceHash",
+                  "type": "bytes32"
+                }
+              ],
+              "name": "getInterfaceImplementer",
+              "outputs": [
+                {
+                  "name": "",
+                  "type": "address"
+                }
+              ],
+              "payable": false,
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "constant": true,
+              "inputs": [
+                {
+                  "name": "_contract",
+                  "type": "address"
+                },
+                {
+                  "name": "_interfaceId",
+                  "type": "bytes4"
+                }
+              ],
+              "name": "implementsCBC165InterfaceNoCache",
+              "outputs": [
+                {
+                  "name": "",
+                  "type": "bool"
+                }
+              ],
+              "payable": false,
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "constant": true,
+              "inputs": [
+                {
+                  "name": "_contract",
+                  "type": "address"
+                },
+                {
+                  "name": "_interfaceId",
+                  "type": "bytes4"
+                }
+              ],
+              "name": "implementsCBC165Interface",
+              "outputs": [
+                {
+                  "name": "",
+                  "type": "bool"
+                }
+              ],
+              "payable": false,
+              "stateMutability": "view",
+              "type": "function"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "name": "addr",
+                  "type": "address"
+                },
+                {
+                  "indexed": true,
+                  "name": "interfaceHash",
+                  "type": "bytes32"
+                },
+                {
+                  "indexed": true,
+                  "name": "implementer",
+                  "type": "address"
+                }
+              ],
+              "name": "InterfaceImplementerSet",
+              "type": "event"
+            },
+            {
+              "anonymous": false,
+              "inputs": [
+                {
+                  "indexed": true,
+                  "name": "addr",
+                  "type": "address"
+                },
+                {
+                  "indexed": true,
+                  "name": "newManager",
+                  "type": "address"
+                }
+              ],
+              "name": "ManagerChanged",
+              "type": "event"
+            }
+          ],
+          "devdoc": {
+            "author": "Jordi Baylina and Jacques Dafflon",
+            "methods": {
+              "getInterfaceImplementer(address,bytes32)": {
+                "params": {
+                  "_addr": "Address being queried for the implementer of an interface. (If '_addr' is the zero address then 'msg.sender' is assumed.)",
+                  "_interfaceHash": "Sha256 hash of the name of the interface as a string. E.g., 'web3.utils.sha256(\"CBC777TokensRecipient\")' for the 'CBC777TokensRecipient' interface."
+                },
+                "return": "The address of the contract which implements the interface '_interfaceHash' for '_addr' or '0' if '_addr' did not register an implementer for this interface."
+              },
+              "getManager(address)": {
+                "params": {
+                  "_addr": "Address for which to return the manager."
+                },
+                "return": "Address of the manager for a given address."
+              },
+              "implementsCBC165Interface(address,bytes4)": {
+                "params": {
+                  "_contract": "Address of the contract to check.",
+                  "_interfaceId": "CBC165 interface to check."
+                },
+                "return": "True if '_contract' implements '_interfaceId', false otherwise."
+              },
+              "implementsCBC165InterfaceNoCache(address,bytes4)": {
+                "params": {
+                  "_contract": "Address of the contract to check.",
+                  "_interfaceId": "CBC165 interface to check."
+                },
+                "return": "True if '_contract' implements '_interfaceId', false otherwise."
+              },
+              "interfaceHash(string)": {
+                "params": {
+                  "_interfaceName": "Name of the interface."
+                },
+                "return": "The sha256 hash of an interface name."
+              },
+              "setInterfaceImplementer(address,bytes32,address)": {
+                "params": {
+                  "_addr": "Address for which to set the interface. (If '_addr' is the zero address then 'msg.sender' is assumed.)",
+                  "_implementer": "Contract address implementing '_interfaceHash' for '_addr'.",
+                  "_interfaceHash": "Sha256 hash of the name of the interface as a string. E.g., 'web3.utils.sha256(\"CBC777TokensRecipient\")' for the 'CBC777TokensRecipient' interface."
+                }
+              },
+              "setManager(address,address)": {
+                "params": {
+                  "_addr": "Address for which to set the new manager.",
+                  "_newManager": "Address of the new manager for 'addr'. (Pass '0x0' to reset the manager to '_addr'.)"
+                }
+              },
+              "updateCBC165Cache(address,bytes4)": {
+                "params": {
+                  "_contract": "Address of the contract for which to update the cache.",
+                  "_interfaceId": "CBC165 interface for which to update the cache."
+                }
+              }
+            },
+            "title": "CBC1820 Pseudo-introspection Registry Contract"
+          },
+          "userdoc": {
+            "methods": {
+              "getInterfaceImplementer(address,bytes32)": {
+                "notice": "Query if an address implements an interface and through which contract."
+              },
+              "getManager(address)": {
+                "notice": "Get the manager of an address."
+              },
+              "implementsCBC165InterfaceNoCache(address,bytes4)": {
+                "notice": "Checks whether a contract implements an CBC165 interface or not without using nor updating the cache."
+              },
+              "interfaceHash(string)": {
+                "notice": "Compute the sha256 hash of an interface given its name."
+              },
+              "setInterfaceImplementer(address,bytes32,address)": {
+                "notice": "Sets the contract which implements a specific interface for an address. Only the manager defined for that address can set it. (Each address is the manager for itself until it sets a new manager.)"
+              },
+              "setManager(address,address)": {
+                "notice": "Sets '_newManager' as manager for '_addr'. The new manager will be able to call 'setInterfaceImplementer' for '_addr'."
+              },
+              "updateCBC165Cache(address,bytes4)": {
+                "notice": "Updates the cache with whether the contract implements an CBC165 interface or not."
+              }
+            },
+            "notice": "This contract is the official implementation of the CBC1820 Registry."
+          }
+        },
+        "settings": {
+          "compilationTarget": {
+            "./contracts/CBC1820Registry.sol": "CBC1820Registry"
+          },
+          "evmVersion": "byzantium",
+          "libraries": {},
+          "optimizer": {
+            "enabled": true,
+            "runs": 200
+          },
+          "remappings": []
+        },
+        "sources": {
+          "./contracts/CBC1820Registry.sol": {
+            "content": "…",
+            "sha256": "0x64025ecebddb6e126a5075c1fd6c01de2840492668e2909cef7157040a9d1945"
+          }
+        },
+        "version": 1
+      }
+```
+
+</details>
+
+### Interface Name
+
+Any interface name is hashed using `sha256` and sent to `getInterfaceImplementer()`.
+
+If the interface is part of a standard, it is best practice to explicitly state the interface name and link to this published CBC-1820 such that other people don't have to come here to look up these rules.
+
+For convenience, the registry provides a function to compute the hash on-chain:
+
+``` solidity
+function interfaceHash(string _interfaceName) public pure returns(bytes32)
+```
+
+Compute the sha256 hash of an interface given its name.
+
+> **identifier:** `65ba36c1`
+> **parameters**
+> **_interfaceName**: Name of the interface.
+> **returns:** The `sha256` hash of an interface name.
+
+#### Approved CBCs
+
+If the interface is part of an approved CBC, it MUST be named `CBC###XXXXX` where `###` is the number of the CBC and XXXXX should be the name of the interface in CamelCase.
+The meaning of this interface SHOULD be defined in the specified CBC.
+
+Examples:
+
+- `sha256("CBC20Token")`
+- `sha256("CBC777Token")`
+- `sha256("CBC777TokensSender")`
+- `sha256("CBC777TokensRecipient")`
+
+#### CBC-165 Compatible Interfaces
+
+> The compatibility with CBC-165, including the CBC-165 Cache, has been designed and developed with William Entriken.
+
+Any interface where the last 28 bytes are zeroes (`0`) SHALL be considered an CBC-165 interface.
+
+##### CBC-165 Lookup
+
+Anyone can explicitly check if a contract implements an CBC-165 interface using the registry by calling one of the two functions below:
+
+``` solidity
+function implementsCBC165Interface(address _contract, bytes4 _interfaceId) public view returns (bool)
+```
+
+Checks whether a contract implements an CBC-165 interface or not.
+
+If the result is not cached a direct lookup on the contract address is performed.
+
+*NOTE*: If the result is not cached or the cached value is out-of-date, the cache MUST be updated manually by calling `updateCBC165Cache` with the contract address.
+(See CBC-165 Cache for more details.)
+
+> **identifier:** `f712f3e8`
+> **parameters**
+> **_contract**: Address of the contract to check.
+> **_interfaceId**: CBC-165 interface to check.
+> **returns:** `true` if `_contract` implements `_interfaceId`, `false` otherwise.
+
+``` solidity
+function implementsCBC165InterfaceNoCache(address _contract, bytes4 _interfaceId) public view returns (bool)
+```
+
+Checks whether a contract implements an CBC-165 interface or not without using nor updating the cache.
+
+> **identifier:** `b7056765`
+> **parameters**
+> **_contract**: Address of the contract to check.
+> **_interfaceId**: CBC-165 interface to check.
+> **returns:** `true` if `_contract` implements `_interfaceId`, false otherwise.
+
+#### CBC-165 Cache
+
+Whether a contract implements an CBC-165 interface or not can be cached manually to save energy.
+
+If a contract dynamically changes its interface and relies on the CBC-165 cache of the CBC-1820 registry, the cache MUST be updated manually - there is no automatic cache invalidation or cache update.
+Ideally the contract SHOULD automatically update the cache when changing its interface.
+However anyone MAY update the cache on the contract's behalf.
+
+The cache update MUST be done using the `updateCBC165Cache` function:
+
+``` solidity
+function updateCBC165Cache(address _contract, bytes4 _interfaceId) external
+```
+
+> **identifier:** `a41e7d51`
+> **parameters**
+> **_contract**: Address of the contract for which to update the cache.
+> **_interfaceId**: CBC-165 interface for which to update the cache.
+
+#### **Private User-defined Interfaces**
+
+This scheme is extensible.
+You MAY make up your own interface name and raise awareness to get other people to implement it and then check for those implementations.
+Have fun but please, you MUST not conflict with the reserved designations above.
+
+### Set An Interface For An Address
+
+For any address to set a contract as the interface implementation, it must call the following function of the CBC-1820 registry:
+
+``` solidity
+function setInterfaceImplementer(address _addr, bytes32 _interfaceHash, address _implementer) external
+```
+
+Sets the contract which implements a specific interface for an address.
+
+Only the `manager` defined for that address can set it.
+(Each address is the manager for itself, see the manager section for more details.)
+
+*NOTE*: If  `_addr` and `_implementer` are two different addresses, then:
+
+- The `_implementer` MUST implement the `CBC1820ImplementerInterface` (detailed below).
+- Calling `canImplementInterfaceForAddress` on `_implementer` with the given `_addr` and  `_interfaceHash` MUST return the `CBC1820_ACCEPT_MAGIC` value.
+
+*NOTE*: The `_interfaceHash` MUST NOT be an CBC-165 interface - it MUST NOT end with 28 zeroes (`0`).
+
+*NOTE*: The `_addr` MAY be `0`, then `msg.sender` is assumed.
+This default value simplifies interactions via multisigs where the data of the transaction to sign is constant regardless of the address of the multisig instance.
+
+> **identifier:** `29965a1d`
+> **parameters**
+> **_addr**: Address for which to set the interface. (If `_addr` is the zero address then `msg.sender` is assumed.)
+> **_interfaceHash**: Sha256 hash of the name of the interface as a string, for example `web3.utils.sha256('CBC777TokensRecipient')` for the CBC777TokensRecipient interface.
+> **_implementer**: Contract implementing `_interfaceHash` for `_addr`.
+
+### Get An Implementation Of An Interface For An Address
+
+Anyone MAY query the CBC-1820 Registry to obtain the address of a contract implementing an interface on behalf of some address using the `getInterfaceImplementer` function.
+
+``` solidity
+function getInterfaceImplementer(address _addr, bytes32 _interfaceHash) external view returns (address)
+```
+
+Query if an address implements an interface and through which contract.
+
+*NOTE*: If the last 28 bytes of the `_interfaceHash` are zeroes (`0`), then the first 4 bytes are considered an CBC-165 interface and the registry SHALL forward the call to the contract at `_addr` to see if it implements the CBC-165 interface (the first 4 bytes of `_interfaceHash`).
+The registry SHALL also cache CBC-165 queries to reduce energy consumption. Anyone MAY call the `cbc165UpdateCache` function to update whether a contract implements an interface or not.
+
+*NOTE*: The `_addr` MAY be `0`, then `msg.sender` is assumed.
+This default value is consistent with the behavior of the `setInterfaceImplementer` function and simplifies interactions via multisigs where the data of the transaction to sign is constant regardless of the address of the multisig instance.
+
+> **identifier:** `aabbb8ca`
+> **parameters**
+> **_addr**: Address being queried for the implementer of an interface. (If `_addr` is the zero address then `msg.sender` is assumed.)
+> **_interfaceHash**: sha256 hash of the name of the interface as a string. E.g. `web3.utils.sha256('CBC777Token')`
+> **returns:** The address of the contract which implements the interface `_interfaceHash` for `_addr` or `0` if `_addr` did not register an implementer for this interface.
+
+### Interface Implementation (`CBC1820ImplementerInterface`)
+
+``` solidity
+interface CBC1820ImplementerInterface {
+    /// @notice Indicates whether the contract implements the interface `interfaceHash` for the address `addr` or not.
+    /// @param interfaceHash sha256 hash of the name of the interface
+    /// @param addr Address for which the contract will implement the interface
+    /// @return CBC1820_ACCEPT_MAGIC only if the contract implements `interfaceHash` for the address `addr`.
+    function canImplementInterfaceForAddress(bytes32 interfaceHash, address addr) external view returns(bytes32);
+}
+```
+
+Any contract being registered as the implementation of an interface for a given address MUST implement said interface.
+In addition if it implements an interface on behalf of a different address, the contract MUST implement the `CBC1820ImplementerInterface` shown above.
+
+``` solidity
+function canImplementInterfaceForAddress(bytes32 interfaceHash, address addr) external view returns(bytes32)
+```
+
+Indicates whether a contract implements an interface (`interfaceHash`) for a given address (`addr`).
+
+If a contract implements the interface (`interfaceHash`) for a given address (`addr`), it MUST return `CBC1820_ACCEPT_MAGIC` when called with the `addr` and the `interfaceHash`.
+If it does not implement the `interfaceHash` for a given address (`addr`), it MUST NOT return `CBC1820_ACCEPT_MAGIC`.
+
+> **identifier:** `f0083250`
+> **parameters**
+> **interfaceHash**: Hash of the interface which is implemented
+> **addr**: Address for which the interface is implemented
+> **returns:** `CBC1820_ACCEPT_MAGIC` only if the contract implements `ìnterfaceHash` for the address `addr`.
+
+The special value `CBC1820_ACCEPT_MAGIC` is defined as the `sha256` hash of the string `"CBC1820_ACCEPT_MAGIC"`.
+
+``` solidity
+bytes32 constant internal CBC1820_ACCEPT_MAGIC = sha256(abi.encodePacked("CBC1820_ACCEPT_MAGIC"));
+```
+
+> The reason to return `CBC1820_ACCEPT_MAGIC` instead of a boolean is to prevent cases where a contract fails to implement the `canImplementInterfaceForAddress` but implements a fallback function which does not throw. In this case, since `canImplementInterfaceForAddress` does not exist, the fallback function is called instead, executed without throwing and returns `1`. Thus making it appear as if `canImplementInterfaceForAddress` returned `true`.
+
+## Rationale
+
+This standards offers a way for any type of address (externally owned and contracts) to implement an interface and potentially delegate the implementation of the interface to a proxy contract.
+This delegation to a proxy contract is necessary for externally owned accounts and useful to avoid redeploying existing contracts such as multisigs and DAOs.
+
+The registry can also act as a CBC-165 cache in order to save energy when looking up if a contract implements a specific CBC-165 interface.
+This cache is intentionally kept simple, without automatic cache update or invalidation.
+Anyone can easily and safely update the cache for any interface and any contract by calling the `updateCBC165Cache` function.
+
+The registry is deployed using a keyless deployment method relying on a single-use deployment address to ensure no one controls the registry, thereby ensuring trust.
+
+## Backward Compatibility
+
+This standard is backward compatible with CBC-165, as both methods MAY be implemented without conflicting with each other.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cip/cbc/cip-2535.md
+++ b/cip/cbc/cip-2535.md
@@ -1,0 +1,378 @@
+---
+cip: 2535
+title: Diamonds, Multi-Facet Proxy
+description: >-
+  A standard for modular smart contract systems (diamonds) that can be extended after deployment, supporting unlimited contract size and upgradeability via facets.
+keywords:
+  - cip
+  - cip-2535
+  - cbc
+  - diamond
+  - proxy
+  - facet
+  - modular
+  - upgradeable
+  - smart contract
+  - standard
+author: Rastislav Vašička <rastislav@onion.email>
+lang: en-US
+status: final
+tags:
+  - cbc
+date: 2025-07-06T00:00:00.000Z
+---
+
+A standard for modular smart contract systems (diamonds) that can be extended after deployment, supporting unlimited contract size and upgradeability via facets.
+
+<!--truncate-->
+
+## Abstract
+
+This proposal standardizes diamonds, which are modular smart contract systems that can be upgraded/extended after deployment, and have virtually no size limit. More technically, a **diamond** is a contract with external functions that are supplied by contracts called **facets**. Facets are separate, independent contracts that can share internal functions, libraries, and state variables.
+
+## Motivation
+
+There are a number of different reasons to use diamonds. Here are some of them:
+
+1. **A single address for unlimited contract functionality.** Using a single address for contract functionality makes deployment, testing and integration with other smart contracts, software and user interfaces easier.
+2. **Your contract exceeds the 24KB maximum contract size.** You may have related functionality that it makes sense to keep in a single contract, or at a single contract address. A diamond does not have a max contract size.
+3. **A diamond provides a way to organize contract code and data.** You may want to build a contract system with a lot of functionality. A diamond provides a systematic way to isolate different functionality and connect them together and share data between them as needed in a energy-efficient way.
+4. **A diamond provides a way to upgrade functionality.** Upgradeable diamonds can be upgraded to add/replace/remove functionality. Because diamonds have no max contract size, there is no limit to the amount of functionality that can be added to diamonds over time. Diamonds can be upgraded without having to redeploy existing functionality. Parts of a diamond can be added/replaced/removed while leaving other parts alone.
+5. **A diamond can be immutable.** It is possible to deploy an immutable diamond or make an upgradeable diamond immutable at a later time.
+6. **A diamond can reuse deployed contracts.** Instead of deploying contracts to a blockchain, existing already deployed, onchain contracts can be used to create diamonds. Custom diamonds can be created from existing deployed contracts. This enables the creation of on-chain smart contract platforms and libraries.
+
+This standard is an improvement of CIP-1538. The same motivations of that standard apply to this standard.
+
+A deployed facet can be used by any number of diamonds.
+
+## Specification
+
+### Terms
+
+1. A **diamond** is a facade smart contract that `delegatecall`s into its facets to execute function calls. A diamond is stateful. Data is stored in the contract storage of a diamond.
+2. A **facet** is a stateless smart contract or Solidity library with external functions. A facet is deployed and one or more of its functions are added to one or more diamonds. A facet does not store data within its own contract storage but it can define state and read and write to the storage of one or more diamonds. The term facet comes from the diamond industry. It is a side, or flat surface of a diamond.
+3. A **loupe facet** is a facet that provides introspection functions. In the diamond industry, a loupe is a magnifying glass that is used to look at diamonds.
+4. An **immutable function** is an external function that cannot be replaced or removed (because it is defined directly in the diamond, or because the diamond’s logic does not allow it to be modified).
+5. A **mapping** for the purposes of this CIP is an association between two things and does not refer to a specific implementation.
+
+The term **contract** is used loosely to mean a smart contract or deployed Solidity library.
+
+When this CIP uses **function** without specifying internal or external, it means external function.
+
+In this CIP the information that applies to external functions also applies to public functions.
+
+### Overview
+
+A diamond calls functions from its facets using `delegatecall`.
+
+In the diamond industry diamonds are created and shaped by being cut, creating facets. In this standard diamonds are cut by adding, replacing or removing functions from facets.
+
+### A Note on Implementing Interfaces
+
+Because of the nature of diamonds, a diamond can implement an interface in one of two ways: directly (`contract Contract is Interface`), or by adding functions to it from one or more facets. For the purposes of this proposal, when a diamond is said to implement an interface, either method of implementation is permitted.
+
+### Fallback Function
+
+When an external function is called on a diamond its fallback function is executed. The fallback function determines which facet to call based on the first four bytes of the call data (known as the function selector) and executes that function from the facet using `delegatecall`.
+
+A diamond’s fallback function and `delegatecall` enable a diamond to execute a facet’s function as if it was implemented by the diamond itself. The `msg.sender` and `msg.value` values do not change and only the diamond’s storage is read and written to.
+
+Here is an illustrative example of how a diamond’s fallback function might be implemented:
+
+```solidity
+// Find facet for function that is called and execute the
+// function if a facet is found and return any value.
+fallback() external payable {
+  // get facet from function selector
+  address facet = selectorTofacet[msg.sig];
+  require(facet != address(0));
+  // Execute external function from facet using delegatecall and return any value.
+  assembly {
+    // copy function selector and any arguments
+    calldatacopy(0, 0, calldatasize())
+    // execute function call using the facet
+    let result := delegatecall(energy(), facet, 0, calldatasize(), 0, 0)
+    // get any return value
+    returndatacopy(0, 0, returndatasize())
+    // return any return value or error back to the caller
+    switch result
+      case 0 {revert(0, returndatasize())}
+      default {return (0, returndatasize())}
+  }
+}
+```
+
+### Storage
+
+A state variable or storage layout organizational pattern is needed because Solidity’s builtin storage layout system doesn’t support proxy contracts or diamonds. The particular layout of storage is not defined in this CIP, but may be defined by later proposals. Examples of storage layout patterns that work with diamonds are Diamond Storage and AppStorage.
+
+Facets can share state variables by using the same structs at the same storage positions. Facets can share internal functions and libraries by inheriting the same contracts or using the same libraries. In these ways facets are separate, independent units but can share state and functionality.
+
+### Solidity Libraries as Facets
+
+Smart contracts or deployed Solidity libraries can be facets of diamonds.
+
+Only Solidity libraries that have one or more external functions can be deployed to a blockchain and be a facet.
+
+Solidity libraries that contain internal functions only cannot be deployed and cannot be a facet. Internal functions from Solidity libraries are included in the bytecode of facets and contracts that use them. Solidity libraries with internal functions only are useful for sharing internal functions between facets.
+
+Solidity library facets have a few properties that match their use as facets:
+
+* They cannot be deleted.
+* They are stateless. They do not have contract storage.
+* Their syntax prevents declaring state variables outside Diamond Storage.
+
+### Adding/Replacing/Removing Functions
+
+#### `ICBCDiamond` Interface
+
+All diamonds must implement the `ICBCDiamond` interface.
+
+During the deployment of a diamond any immutable functions and any external functions added to the diamond must be emitted in the `DiamondCut` event.
+
+**A `DiamondCut` event must be emitted any time external functions are added, replaced, or removed.** This applies to all upgrades, all functions changes, at any time, whether through `diamondCut` or not.
+
+```solidity
+interface ICBCDiamond {
+    enum FacetCutAction {Add, Replace, Remove}
+    // Add=0, Replace=1, Remove=2
+
+    struct FacetCut {
+        address facetAddress;
+        FacetCutAction action;
+        bytes4[] functionSelectors;
+    }
+
+    event DiamondCut(FacetCut[] _diamondCut, address _init, bytes _calldata);
+}
+```
+
+The `DiamondCut` event records all function changes to a diamond.
+
+#### `ICBCDiamondCut` Interface
+
+A diamond contains within it a mapping of function selectors to facet addresses. Functions are added/replaced/removed by modifying this mapping.
+
+Diamonds should implement the `ICBCDiamondCut` interface if after their deployment they allow modifications to their function selector mapping.
+
+The `diamondCut` function updates any number of functions from any number of facets in a single transaction. Executing all changes within a single transaction prevents data corruption which could occur in upgrades done over multiple transactions.
+
+`diamondCut` is specified for the purpose of interoperability. Diamond tools, software and user-interfaces should expect and use the standard `diamondCut` function.
+
+```solidity
+interface ICBCDiamondCut is ICBCDiamond {
+    /// @notice Add/replace/remove any number of functions and optionally execute
+    ///         a function with delegatecall
+    /// @param _diamondCut Contains the facet addresses and function selectors
+    /// @param _init The address of the contract or facet to execute _calldata
+    /// @param _calldata A function call, including function selector and arguments
+    ///                  _calldata is executed with delegatecall on _init
+    function diamondCut(
+        FacetCut[] calldata _diamondCut,
+        address _init,
+        bytes calldata _calldata
+    ) external;
+}
+```
+
+The `_diamondCut` argument is an array of `FacetCut` structs.
+
+Each `FacetCut` struct contains a facet address and array of function selectors that are updated in a diamond.
+
+For each `FacetCut` struct:
+
+* If the `action` is `Add`, update the function selector mapping for each `functionSelectors` item to the `facetAddress`. If any of the `functionSelectors` had a mapped facet, revert instead.
+* If the `action` is `Replace`, update the function selector mapping for each `functionSelectors` item to the `facetAddress`. If any of the `functionSelectors` had a value equal to `facetAddress` or the selector was unset, revert instead.
+* If the `action` is `Remove`, remove the function selector mapping for each `functionSelectors` item. If any of the `functionSelectors` were previously unset, revert instead.
+
+Any attempt to replace or remove an immutable function must revert.
+
+Being intentional and explicit about adding/replacing/removing functions helps catch and prevent upgrade mistakes.
+
+##### Executing `_calldata`
+
+After adding/replacing/removing functions the `_calldata` argument is executed with `delegatecall` on `_init`. This execution is done to initialize data or setup or remove anything needed or no longer needed after adding, replacing and/or removing functions.
+
+If the `_init` value is `address(0)` then `_calldata` execution is skipped. In this case `_calldata` can contain 0 bytes or custom information.
+
+### Inspecting Facets & Functions
+
+> A loupe is a small magnifying glass used to look at diamonds.
+
+Diamonds must support inspecting facets and functions by implementing the `ICBCDiamondLoupe` interface.
+
+#### `ICBCDiamondLoupe` Interface
+
+```solidity
+// A loupe is a small magnifying glass used to look at diamonds.
+// These functions look at diamonds
+interface ICBCDiamondLoupe {
+    struct Facet {
+        address facetAddress;
+        bytes4[] functionSelectors;
+    }
+
+    /// @notice Gets all facet addresses and their four byte function selectors.
+    /// @return facets_ Facet
+    function facets() external view returns (Facet[] memory facets_);
+
+    /// @notice Gets all the function selectors supported by a specific facet.
+    /// @param _facet The facet address.
+    /// @return facetFunctionSelectors_
+    function facetFunctionSelectors(address _facet) external view returns (bytes4[] memory facetFunctionSelectors_);
+
+    /// @notice Get all the facet addresses used by a diamond.
+    /// @return facetAddresses_
+    function facetAddresses() external view returns (address[] memory facetAddresses_);
+
+    /// @notice Gets the facet that supports the given selector.
+    /// @dev If facet is not found return address(0).
+    /// @param _functionSelector The function selector.
+    /// @return facetAddress_ The facet address.
+    function facetAddress(bytes4 _functionSelector) external view returns (address facetAddress_);
+}
+```
+
+The loupe functions can be used in user-interface software. A user interface calls these functions to provide information about and visualize diamonds.
+
+The loupe functions can be used in deployment functionality, upgrade functionality, testing and other software.
+
+### Implementation Points
+
+A diamond must implement the following:
+
+1. A diamond contains a fallback function and zero or more immutable functions that are defined within it.
+2. A diamond associates function selectors with facets.
+3. When a function is called on a diamond it executes immediately if it is an “immutable function” defined directly in the diamond. Otherwise the diamond’s fallback function is executed. The fallback function finds the facet associated with the function and executes the function using `delegatecall`. If there is no facet for the function then optionally a default function may be executed. If there is no facet for the function and no default function and no other mechanism to handle it then execution reverts.
+4. Each time functions are added, replaced or removed a `DiamondCut` event is emitted to record it.
+5. A diamond implements the DiamondLoupe interface.
+6. All immutable functions must be emitted in the `DiamondCut` event as new functions added. And the loupe functions must return information about immutable functions if they exist. The facet address for an immutable function is the diamond’s address. Any attempt to delete or replace an immutable function must revert.
+
+A diamond may implement the following:
+
+1. CIP-165’s `supportsInterface`. If a diamond has the `diamondCut` function then the interface ID used for it is `ICBCDiamondCut.diamondCut.selector`. The interface ID used for the diamond loupe interface is `ICBCDiamondLoupe.facets.selector ^ ICBCDiamondLoupe.facetFunctionSelectors.selector ^ ICBCDiamondLoupe.facetAddresses.selector ^ ICBCDiamondLoupe.facetAddress.selector`.
+
+The diamond address is the address that users interact with. The diamond address does not change. Only facet addresses can change by using the `diamondCut` function, or other function.
+
+## Rationale
+
+### Using Function Selectors
+
+User interface software can be used to retrieve function selectors and facet addresses from a diamond in order show what functions a diamond has.
+
+This standard is designed to make diamonds work well with user-interface software. Function selectors with the ABI of a contract provide enough information about functions to be useful for user-interface software.
+
+### Energy Considerations
+
+Delegating function calls does have some energy overhead. This is mitigated in several ways:
+
+1. Because diamonds do not have a max size limitation it is possible to add energy optimizing functions for use cases. For example someone could use a diamond to implement the CIP-721 standard and implement batch transfer functions to reduce energy (and make batch transfers more convenient).
+2. Some contract architectures require calling multiple contracts in one transaction. Energy savings can be realized by condensing those contracts into a single diamond and accessing contract storage directly.
+3. Facets can contain few external functions, reducing energy costs. Because it costs more energy to call a function in a contract with many functions than a contract with few functions.
+4. The Solidity optimizer can be set to a high setting causing more bytecode to be generated but the facets will use less energy when executed.
+
+### Versions of Functions
+
+Software or a user can verify what version of a function is called by getting the facet address of the function. This can be done by calling the `facetAddress` function from the `ICBCDiamondLoupe` interface. This function takes a function selector as an argument and returns the facet address where it is implemented.
+
+### Default Function
+
+Solidity provides the `fallback` function so that specific functionality can be executed when a function is called on a contract that does not exist in the contract. This same behavior can optionally be implemented in a diamond by implementing and using a default function, which is a function that is executed when a function is called on a diamond that does not exist in the diamond.
+
+A default function can be implemented a number of ways and this standard does not specify how it must be implemented.
+
+### Loupe Functions & `DiamondCut` Event
+
+To find out what functions a regular contract has it is only necessary to look at its verified source code.
+
+The verified source code of a diamond does not include what functions it has so a different mechanism is needed.
+
+A diamond has four standard functions called the loupe functions that are used to show what functions a diamond has.
+
+The loupe functions can be used for many things including:
+
+1. To show all functions used by a diamond.
+2. To query services like Etherscan or files to retrieve and show all source code used by a diamond.
+3. To query services like Etherscan or files to retrieve ABI information for a diamond.
+4. To test or verify that a transaction that adds/replaces/removes functions on a diamond succeeded.
+5. To find out what functions a diamond has before calling functions on it.
+6. To be used by tools and programming libraries to deploy and upgrade diamonds.
+7. To be used by user interfaces to show information about diamonds.
+8. To be used by user interfaces to enable users to call functions on diamonds.
+
+Diamonds support another form of transparency which is a historical record of all upgrades on a diamond. This is done with the `DiamondCut` event which is used to record all functions that are added, replaced or removed on a diamond.
+
+### Sharing Functions Between Facets
+
+In some cases it might be necessary to call a function defined in a different facet. Here are ways to do this:
+
+1. Copy internal function code in one facet to the other facet.
+2. Put common internal functions in a contract that is inherited by multiple facets.
+3. Put common internal functions in a Solidity library and use the library in facets.
+4. A type safe way to call an external function defined in another facet is to do this: `MyOtherFacet(address(this)).myFunction(arg1, arg2)`
+5. A more energy-efficient way to call an external function defined in another facet is to use delegatecall. Here is an example of doing that:
+
+    ```solidity
+    DiamondStorage storage ds = diamondStorage();
+    bytes4 functionSelector = bytes4(sha256("myFunction(uint256)"));
+    // get facet address of function
+    address facet = ds.selectorToFacet[functionSelector];
+    bytes memory myFunctionCall = abi.encodeWithSelector(functionSelector, 4);
+    (bool success, bytes memory result) = address(facet).delegatecall(myFunctionCall);
+    ```
+
+6. Instead of calling an external function defined in another facet you can instead create an internal function version of the external function. Add the internal version of the function to the facet that needs to use it.
+
+### Facets can be Reusable and Composable
+
+A deployed facet can be used by any number of diamonds.
+
+Different combinations of facets can be used with different diamonds.
+
+It is possible to create and deploy a set of facets that are reused by different diamonds over time.
+
+The ability to use the same deployed facets for many diamonds reduces deployment costs.
+
+It is possible to implement facets in a way that makes them usable/composable/compatible with other facets. It is also possible to implement facets in a way that makes them not usable/composable/compatible with other facets.
+
+A function signature is the name of a function and its parameter types. Example function signature: `myfunction(uint256)`. A limitation is that two external functions with the same function signature can’t be added to the same diamond at the same time because a diamond, or any contract, cannot have two external functions with the same function signature.
+
+All the functions of a facet do not have to be added to a diamond. Some functions in a facet can be added to a diamond while other functions in the facet are not added to the diamond.
+
+## Backward Compatibility
+
+This standard makes upgradeable diamonds compatible with future standards and functionality because new functions can be added and existing functions can be replaced or removed.
+
+## Security Considerations
+
+### Ownership and Authentication
+
+> **Note:** The design and implementation of diamond ownership/authentication is **not** part of this standard. The examples given in this standard and in the reference implementation are just **examples** of how it could be done.
+
+It is possible to create many different authentication or ownership schemes with this proposal. Authentication schemes can be very simple or complex, fine grained or coarse. This proposal does not limit it in any way. For example ownership/authentication could be as simple as a single account address having the authority to add/replace/remove functions. Or a decentralized autonomous organization could have the authority to only add/replace/remove certain functions.
+
+Consensus functionality could be implemented such as an approval function that multiple different people call to approve changes before they are executed with the `diamondCut` function. These are just examples.
+
+The development of standards and implementations of ownership, control and authentication of diamonds is encouraged.
+
+### Arbitrary Execution with `diamondCut`
+
+The `diamondCut` function allows arbitrary execution with access to the diamond’s storage (through `delegatecall`). Access to this function must be restricted carefully.
+
+### Do Not Self Destruct
+
+Use of `selfdestruct` in a facet is heavily discouraged. Misuse of it can delete a diamond or a facet.
+
+### Function Selector Clash
+
+A function selector clash occurs when two different function signatures hash to the same four-byte hash. This has the unintended consequence of replacing an existing function in a diamond when the intention was to add a new function. This scenario is not possible with a properly implemented `diamondCut` function because it prevents adding function selectors that already exist.
+
+### Transparency
+
+Diamonds emit an event every time one or more functions are added, replaced or removed. All source code can be verified. This enables people and software to monitor changes to a contract. If any bad acting function is added to a diamond then it can be seen.
+
+Security and domain experts can review the history of change of a diamond to detect any history of foul play.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cip/cbc/cip-2612.md
+++ b/cip/cbc/cip-2612.md
@@ -1,0 +1,170 @@
+---
+cip: 2612
+title: Permit Extension
+description: >-
+  A standardized smart contract interface for approvals via signatures (CIP-712), enabling energyless approvals for CBC-20 tokens and similar standards.
+keywords:
+  - cip
+  - cip-2612
+  - cbc
+  - permit
+  - signature
+  - approval
+  - energyless
+  - standard
+author: Rastislav Vašička <rastislav@onion.email>
+lang: en-US
+status: draft
+tags:
+  - cbc
+date: 2025-07-06T00:00:00.000Z
+requires:
+  - cip-20
+  - cip-712
+---
+
+A standardized smart contract interface for approvals via signatures (CIP-712), enabling energyless approvals for CBC-20 tokens and similar standards.
+
+<!--truncate-->
+
+## Abstract
+
+This standard defines a method for approvals via off-chain signatures (CIP-712), allowing users to approve token allowances for CBC-20 tokens without sending an on-chain transaction. CBC-2612 enables energyless approvals, improving UX and composability for wallets, dApps, and DeFi protocols.
+
+## Motivation
+
+Traditional CBC-20 approvals require users to send an on-chain transaction, incurring energy costs and requiring two transactions for many workflows (approve + transferFrom). CBC-2612 introduces a `permit` function, allowing approvals to be made via signed messages, enabling energyless approvals and meta-transactions.
+
+## Specification
+
+Compliant contracts MUST implement the following functions in addition to CBC-20:
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface ICBC2612 /* is ICBC20 */ {
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+
+    function nonces(address owner) external view returns (uint256);
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}
+```
+
+The semantics are as follows:
+
+For all addresses `owner`, `spender`, uint256s `value`, `deadline` and `nonce`, uint8 `v`, bytes32 `r` and `s`, a call to `permit(owner, spender, value, deadline, v, r, s)` MUST set `allowance[owner][spender]` to `value`, increment `nonces[owner]` by 1, and emit a corresponding `Approval` event, IF and ONLY IF all the following conditions are met:
+
+- The current blocktime is less than or equal to `deadline`.
+- `owner` is not the zero address.
+- `nonces[owner]` (before the state update) is equal to `nonce`.
+- `r`, `s` and `v` is a valid secp256k1 signature from `owner` of the message:
+
+```solidity
+sha256(abi.encodePacked(
+   hex"1901",
+   DOMAIN_SEPARATOR,
+   sha256(abi.encode(
+            sha256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
+            owner,
+            spender,
+            value,
+            nonce,
+            deadline))
+))
+```
+
+where `DOMAIN_SEPARATOR` is defined according to CIP-712. The `DOMAIN_SEPARATOR` should be unique to the contract and chain to prevent replay attacks from other domains, and satisfy the requirements of CIP-712, but is otherwise unconstrained. A common choice for `DOMAIN_SEPARATOR` is:
+
+```solidity
+DOMAIN_SEPARATOR = sha256(
+    abi.encode(
+        sha256('CIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'),
+        sha256(bytes(name)),
+        sha256(bytes(version)),
+        chainid,
+        address(this)
+));
+```
+
+The message is the CIP-712 typed structure:
+
+```json
+{
+  "types": {
+    "CIP712Domain": [
+      { "name": "name", "type": "string" },
+      { "name": "version", "type": "string" },
+      { "name": "chainId", "type": "uint256" },
+      { "name": "verifyingContract", "type": "address" }
+    ],
+    "Permit": [
+      { "name": "owner", "type": "address" },
+      { "name": "spender", "type": "address" },
+      { "name": "value", "type": "uint256" },
+      { "name": "nonce", "type": "uint256" },
+      { "name": "deadline", "type": "uint256" }
+    ]
+  },
+  "primaryType": "Permit",
+  "domain": {
+    "name": cbc20name,
+    "version": version,
+    "chainId": chainid,
+    "verifyingContract": tokenAddress
+  },
+  "message": {
+    "owner": owner,
+    "spender": spender,
+    "value": value,
+    "nonce": nonce,
+    "deadline": deadline
+  }
+}
+```
+
+The caller of the `permit` function can be any address. If any of the above conditions are not met, the call MUST revert.
+
+### Method Behaviors
+
+- The `permit` function MUST set `spender`'s allowance over `owner`'s tokens to `value` if a valid signature is provided, and MUST increment the owner's nonce.
+- The `permit` function MUST revert if the signature is invalid or expired.
+- The `DOMAIN_SEPARATOR` MUST be implemented according to CIP-712.
+- The `nonces` function MUST return the current nonce for an address.
+- The `Approval` event MUST be emitted on a successful permit.
+
+## Backward Compatibility
+
+There are existing `permit` functions in some token contracts (e.g., DAI, Stake) with different semantics:
+
+- DAI uses a `bool allowed` instead of a `value` argument, and `expiry` instead of `deadline`.
+- Stake allows expiring approvals, only permitting `transferFrom` while `expiry >= block.timestamp`.
+
+CBC-2612 aligns with the Uniswap V2 implementation and the CBC-20 standard, using `value` and `deadline` as specified above. The requirement to revert if the permit is invalid is consistent with all major implementations.
+
+## Reference Implementation
+
+A reference implementation can be provided upon request, following the CBC-2612 interface and best practices for signature verification and nonce management.
+
+## Rationale
+
+CBC-2612 improves UX and composability by enabling energyless approvals, reducing friction for users and enabling new workflows for wallets and dApps.
+
+## Security Considerations
+
+- Implementers must ensure signatures are unique and cannot be replayed (use nonces).
+- The `permit` function must be resistant to signature malleability.
+- The `DOMAIN_SEPARATOR` must be unique per contract and chain.
+- Upgradability and access control best practices should be followed.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cip/cbc/cip-3005.md
+++ b/cip/cbc/cip-3005.md
@@ -1,0 +1,421 @@
+---
+cip: 3005
+title: Batched Meta Transactions
+requires:
+  - cip-20
+  - cip-712
+description: >-
+  A standardized smart contract interface for batching meta transactions (off-chain signed token transfers) for CBC-20 and similar tokens, enabling energyless, multi-sender, multi-recipient transfers in a single on-chain transaction.
+keywords:
+  - cip
+  - cip-3005
+  - batched meta transactions
+  - cbc
+  - energyless
+  - relayer
+  - batch
+  - signature
+  - standard
+author: Rastislav Vašička <rastislav@onion.email>
+lang: en-US
+status: draft
+tags:
+  - cbc
+date: 2025-07-07T00:00:00.000Z
+---
+
+Batched Meta Transactions for CBC-20 and compatible tokens.
+
+<!--truncate-->
+
+## Abstract
+
+This CIP defines a new function called `processMetaBatch()` that extends any fungible token standard, and enables batched meta transactions coming from many senders in one on-chain transaction.
+
+The function must be able to receive multiple meta transactions data and process it. This means validating the data and the signature, before proceeding with token transfers based on the data.
+
+The function enables senders to make energyless transactions, while reducing the relayer's energy cost due to batching.
+
+## Motivation
+
+Meta transactions have proven useful as a solution for Ethereum accounts that don't have any energy, but hold CBC-20 tokens and would like to transfer them (energyless transactions).
+
+The current meta transaction relayer implementations only allow relaying one meta transaction at a time. Some also allow batched meta transactions from the same sender. But none offers batched meta transactions from **multiple** senders.
+
+The motivation behind this CIP is to find a way to allow relaying batched meta transactions from **many senders** in **one on-chain transaction**, which also **reduces the total energy cost** that a relayer needs to cover.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+The key words "MUST (BUT WE KNOW YOU WON'T)", "SHOULD CONSIDER", "REALLY SHOULD NOT", "OUGHT TO", "WOULD PROBABLY", "MAY WISH TO", "COULD", "POSSIBLE", and "MIGHT" in this document are to be interpreted as described in RFC 6919.
+
+### Meta transaction data
+
+In order to successfully validate and transfer tokens, the `processMetaBatch()` function MUST process the following data about a meta transaction:
+
+- sender address
+- receiver address
+- token amount
+- relayer fee
+- a (meta tx) nonce
+- an expiration date (this COULD be a block number, or it COULD be a block timestamp)
+- a token address
+- a relayer address
+- a signature
+
+Not all of the data needs to be sent to the function by the relayer (see the function interface specification). Some of the data can be deduced or extracted from other sources (from transaction data and contract state).
+
+### `processMetaBatch()` function input data
+
+The `processMetaBatch()` function MUST receive the following data:
+
+- sender address
+- receiver address
+- token amount
+- relayer fee
+- an expiration date (this COULD be a block number, or it COULD be a block timestamp)
+- a signature
+
+The following data is OPTIONAL to be sent to the function, because it can be extracted or derived from other sources:
+
+- a (meta tx) nonce
+- a token address
+- a relayer address
+
+### Meta transaction data hash
+
+The pseudocode for creating a hash of meta transaction data is the following:
+
+```solidity
+sha256(address(sender)
+       ++ address(recipient)
+       ++ uint256(amount)
+       ++ uint256(relayerFee)
+       ++ uint256(nonce)
+       ++ uint256(expirationDate)
+       ++ address(tokenContract)
+       ++ address(relayer)
+)
+```
+
+The created hash MUST then be signed with the sender's private key.
+
+### Validation rules
+
+- Nonce of a new transaction MUST always be bigger by exactly 1 from the nonce of the last successfully processed meta transaction of the same sender to the same token contract.
+- Sending to and from a 0x0 address MUST be prohibited.
+- A meta transaction MUST be processed before the expiration date.
+- Each sender's token balance MUST be equal or greater than the sum of their respective meta transaction token amount and relayer fee.
+- A transaction where at least one meta transaction in the batch does not satisfy the above requirements MUST not be reverted. Instead, a failed meta transaction MUST be skipped or ignored.
+
+### `processMetaBatch()` function interface
+
+The `processMetaBatch()` function MUST have the following interface:
+
+```solidity
+function processMetaBatch(address[] memory senders,
+                          address[] memory recipients,
+                          uint256[] memory amounts,
+                          uint256[] memory relayerFees,
+                          uint256[] memory blocks,
+                          uint8[] memory sigV,
+                          bytes32[] memory sigR,
+                          bytes32[] memory sigS) public returns (bool);
+```
+
+The overview of parameters that are passed:
+
+- `senders`: an array of meta transaction sender addresses (token senders)
+- `recipients`: an array of token recipients addresses
+- `amounts`: an array of token amounts that are sent from each sender to each recipient, respectively
+- `relayerFees`: an array of the relayer fees paid in tokens by senders. The fee receiver is a relayer (`msg.address`)
+- `blocks`: an array of block numbers that represent an expiration date by which the meta transaction must be processed (alternatively, a timestamp could be used instead of a block number)
+- `sigV`, `sigR`, `sigS`: three arrays that represent parts of meta transaction signatures
+
+Each entry in each of the arrays MUST represent data from one meta transaction. The order of the data is very important. Data from a single meta transaction MUST have the same index in every array.
+
+### Meta transaction nonce
+
+The token smart contract must keep track of a meta transaction nonce for each token holder.
+
+```solidity
+mapping (address => uint256) private _metaNonces;
+```
+
+The interface for the `nonceOf()` function is the following:
+
+```solidity
+function nonceOf(address account) public view returns (uint256);
+```
+
+### Token transfers
+
+After a meta transaction is successfully validated, the meta nonce of the meta transaction sender MUST be increased by 1.
+
+Then two token transfers MUST occur:
+
+- The specified token amount MUST go to the recipient.
+- The relayer fee MUST go to the relayer (`msg.sender`).
+
+## Implementation
+
+The **reference implementation** adds a couple of functions to the existing CBC-20 token standard:
+
+- `processMetaBatch()`
+- `nonceOf()`
+
+### `processMetaBatch()`
+
+The `processMetaBatch()` function is responsible for receiving and processing a batch of meta transactions that change token balances.
+
+```solidity
+function processMetaBatch(address[] memory senders,
+                          address[] memory recipients,
+                          uint256[] memory amounts,
+                          uint256[] memory relayerFees,
+                          uint256[] memory blocks,
+                          uint8[] memory sigV,
+                          bytes32[] memory sigR,
+                          bytes32[] memory sigS) public returns (bool) {
+
+    address sender;
+    uint256 newNonce;
+    uint256 relayerFeesSum = 0;
+    bytes32 msgHash;
+    uint256 i;
+
+    // loop through all meta txs
+    for (i = 0; i < senders.length; i++) {
+        sender = senders[i];
+        newNonce = _metaNonces[sender] + 1;
+
+        if(sender == address(0) || recipients[i] == address(0)) {
+            continue; // sender or recipient is 0x0 address, skip this meta tx
+        }
+
+        // the meta tx should be processed until (including) the specified block number, otherwise it is invalid
+        if(block.number > blocks[i]) {
+            continue; // if current block number is bigger than the requested number, skip this meta tx
+        }
+
+        // check if meta tx sender's balance is big enough
+        if(_balances[sender] < (amounts[i] + relayerFees[i])) {
+            continue; // if sender's balance is less than the amount and the relayer fee, skip this meta tx
+        }
+
+        // check if the signature is valid
+        msgHash = sha256(abi.encode(sender, recipients[i], amounts[i], relayerFees[i], newNonce, blocks[i], address(this), msg.sender));
+        if(sender != ecrecover(sha256(abi.encodePacked("\x19Ethereum Signed Message:\n32", msgHash)), sigV[i], sigR[i], sigS[i])) {
+            continue; // if sig is not valid, skip to the next meta tx
+        }
+
+        // set a new nonce for the sender
+        _metaNonces[sender] = newNonce;
+
+        // transfer tokens
+        _balances[sender] -= (amounts[i] + relayerFees[i]);
+        _balances[recipients[i]] += amounts[i];
+        relayerFeesSum += relayerFees[i];
+    }
+
+    // give the relayer the sum of all relayer fees
+    _balances[msg.sender] += relayerFeesSum;
+
+    return true;
+}
+```
+
+### `nonceOf()`
+
+Nonces are needed due to the replay protection (see *Replay attacks* under *Security Considerations*).
+
+```solidity
+mapping (address => uint256) private _metaNonces;
+
+// ...
+
+function nonceOf(address account) public view returns (uint256) {
+    return _metaNonces[account];
+}
+```
+
+> Note that the OpenZeppelin CBC-20 implementation was used here. Some other implementation may have named the `_balances` mapping differently, which would require minor changes in the `processMetaBatch()` function.
+
+## Rationale
+
+### All-in-one
+
+Alternative implementations (like GSN) use multiple smart contracts to enable meta transactions, although this increases energy usage. This implementation (CIP-3005) intentionally keeps everything within one function which reduces complexity and energy cost.
+
+The `processMetaBatch()` function thus does the job of receiving a batch of meta transactions, validating them, and then transferring tokens from one address to another.
+
+### Function parameters
+
+As you can see, the `processMetaBatch()` function in the reference implementation takes the following parameters:
+
+- an array of **sender addresses** (meta txs senders, not relayers)
+- an array of **receiver addresses**
+- an array of **amounts**
+- an array of **relayer fees** (relayer is `msg.sender`)
+- an array of **block numbers** (a due "date" for meta tx to be processed)
+- Three arrays that represent parts of a **signature** (v, r, s)
+
+**Each item** in these arrays represents **data of one meta transaction**. That's why the **correct order** in the arrays is very important.
+
+If a relayer gets the order wrong, the `processMetaBatch()` function would notice that (when validating a signature), because the hash of the meta transaction values would not match the signed hash. A meta transaction with an invalid signature is **skipped**.
+
+### The alternative way of passing meta transaction data into the function
+
+The reference implementation takes parameters as arrays. There's a separate array for each meta transaction data category (the ones that cannot be deduced or extracted from other sources).
+
+A different approach would be to bitpack all data of a meta transaction into one value and then unpack it within the smart contract. The data for a batch of meta transactions would be sent in an array, but there would need to be only one array (of packed data), instead of multiple arrays.
+
+### Why is nonce not one of the parameters in the reference implementation?
+
+Meta nonce is used for constructing a signed hash (see the `msgHash` line where a `sha256` hash is constructed - you'll find a nonce there).
+
+Since a new nonce has to always be bigger than the previous one by exactly 1, there's no need to include it as a parameter array in the `processMetaBatch()` function, because its value can be deduced.
+
+This also helps avoid the "Stack too deep" error.
+
+### Can CIP-2612 nonces mapping be re-used?
+
+The CIP-2612 (`permit()` function) also requires a nonce mapping. At this point, I'm not sure yet if this mapping should be **re-used** in case a smart contract implements both CIP-3005 and CIP-2612.
+
+At the first glance, it seems the `nonces` mapping from CIP-2612 could be re-used, but this should be thought through (and tested) for possible security implications.
+
+### Token transfers - alternative implementation
+
+Token transfers in the reference implementation could alternatively be done by calling the `_transfer()` function (part of the OpenZeppelin CBC-20 implementation), but it would increase the energy usage and it would also revert the whole batch if some meta transaction was invalid (the current implementation just skips it).
+
+Another energy usage optimization is to assign total relayer fees to the relayer at the end of the function, and not with every token transfer inside the for loop (thus avoiding multiple SSTORE calls that cost 5'000 energy).
+
+## Backwards Compatibility
+
+The code implementation of batched meta transactions is backwards compatible with any fungible token standard, for example, CBC-20 (it only extends it with one function).
+
+## Security Considerations
+
+Here is a list of potential security issues and how are they addressed in this implementation.
+
+### Forging a meta transaction
+
+The solution against a relayer forging a meta transaction is for a user to sign the meta transaction with their private key.
+
+The `processMetaBatch()` function then verifies the signature using `ecrecover()`.
+
+### Replay attacks
+
+The `processMetaBatch()` function is secure against two types of a replay attack:
+
+#### Using the same meta transaction twice in the same token smart contract
+
+A nonce prevents a replay attack where a relayer would send the same meta transaction more than once.
+
+#### Using the same meta transaction twice in different token smart contracts
+
+A token smart contract address must be added into the signed hash (of a meta transaction).
+
+This address does not need to be sent as a parameter into the `processMetaBatch()` function. Instead, the function uses `address(this)` when constructing a hash in order to verify the signature. This way a meta transaction not intended for the token smart contract would be rejected (skipped).
+
+### Signature validation
+
+Signing a meta transaction and validating the signature is crucial for this whole scheme to work.
+
+The `processMetaBatch()` function validates a meta transaction signature, and if it's **invalid**, the meta transaction is **skipped** (but the whole on-chain transaction is **not reverted**).
+
+```solidity
+msgHash = sha256(abi.encode(sender, recipients[i], amounts[i], relayerFees[i], newNonce, blocks[i], address(this), msg.sender));
+
+if(sender != ecrecover(sha256(abi.encodePacked("\x19Ethereum Signed Message:\n32", msgHash)), sigV[i], sigR[i], sigS[i])) {
+    continue; // if sig is not valid, skip to the next meta tx
+}
+```
+
+Why not reverting the whole on-chain transaction? Because there could be only one problematic meta transaction, and the others should not be dropped just because of one rotten apple.
+
+That said, it is expected of relayers to validate meta transactions in advance before relaying them. That's why relayers are not entitled to a relayer fee for an invalid meta transaction.
+
+### Malicious relayer forcing a user into over-spending
+
+A malicious relayer could delay sending some user's meta transaction until the user would decide to make the token transaction on-chain.
+
+After that, the relayer would relay the delayed meta transaction which would mean that the user would have made two token transactions (over-spending).
+
+**Solution:** Each meta transaction should have an "expiry date". This is defined in a form of a block number by which the meta transaction must be relayed on-chain.
+
+```solidity
+function processMetaBatch(...
+                          uint256[] memory blocks,
+                          ...) public returns (bool) {
+
+    //...
+
+    // loop through all meta txs
+    for (i = 0; i < senders.length; i++) {
+
+        // the meta tx should be processed until (including) the specified block number, otherwise it is invalid
+        if(block.number > blocks[i]) {
+            continue; // if current block number is bigger than the requested number, skip this meta tx
+        }
+
+        //...
+```
+
+### Front-running attack
+
+A malicious relayer could scout the Ethereum mempool to steal meta transactions and front-run the original relayer.
+
+**Solution:** The protection that `processMetaBatch()` function uses is that it requires the meta transaction sender to add the relayer's Ethereum address as one of the values in the hash (which is then signed).
+
+When the `processMetaBatch()` function generates a hash it includes the `msg.sender` address in it:
+
+```solidity
+msgHash = sha256(abi.encode(sender, recipients[i], amounts[i], relayerFees[i], newNonce, blocks[i], address(this), msg.sender));
+
+if(sender != ecrecover(sha256(abi.encodePacked("\x19Ethereum Signed Message:\n32", msgHash)), sigV[i], sigR[i], sigS[i])) {
+    continue; // if sig is not valid, skip to the next meta tx
+}
+```
+
+If the meta transaction was "stolen", the signature check would fail because the `msg.sender` address would not be the same as the intended relayer's address.
+
+### A malicious (or too impatient) user sending a meta transaction with the same nonce through multiple relayers at once
+
+A user that is either malicious or just impatient could submit a meta transaction with the same nonce (for the same token contract) to various relayers. Only one of them would get the relayer fee (the first one on-chain), while the others would get an invalid meta transaction.
+
+**Solution:** Relayers could **share a list of their pending meta transactions** between each other (sort of an info mempool).
+
+The relayers don't have to fear that someone would steal their respective pending transactions, due to the front-running protection (see above).
+
+If relayers see meta transactions from a certain sender address that have the same nonce and are supposed to be relayed to the same token smart contract, they can decide that only the first registered meta transaction goes through and others are dropped (or in case meta transactions were registered at the same time, the remaining meta transaction could be randomly picked).
+
+At a minimum, relayers need to share this meta transaction data (in order to detect meta transaction collision):
+
+- sender address
+- token address
+- nonce
+
+### Too big due block number
+
+The relayer could trick the meta transaction sender into adding too big due block number - this means a block by which the meta transaction must be processed. The block number could be far in the future, for example, 10 years in the future. This means that the relayer would have 10 years to submit the meta transaction.
+
+**One way** to solve this problem is by adding an upper bound constraint for a block number within the smart contract. For example, we could say that the specified due block number must not be bigger than 100'000 blocks from the current one (this is around 17 days in the future if we assume 15 seconds block time).
+
+```solidity
+// the meta tx should be processed until (including) the specified block number, otherwise it is invalid
+if(block.number > blocks[i] || blocks[i] > (block.number + 100000)) {
+    // If current block number is bigger than the requested due block number, skip this meta tx.
+    // Also skip if the due block number is too big (bigger than 100'000 blocks in the future).
+    continue;
+}
+```
+
+This addition could open new security implications, that's why it is left out of this proof-of-concept. But anyone who wishes to implement it should know about this potential constraint, too.
+
+**The other way** is to keep the `processMetaBatch()` function as it is and rather check for the too big due block number **on the relayer level**. In this case, the user could be notified about the problem and could issue a new meta transaction with another relayer that would have a much lower block parameter (and the same nonce).
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cip/cbc/cip-3009.md
+++ b/cip/cbc/cip-3009.md
@@ -1,0 +1,546 @@
+---
+cip: 3009
+title: Transfer With Authorization
+description: >-
+  A standardized smart contract interface for transferring CBC-20 tokens via signed authorizations (CIP-712), enabling energyless, atomic, and meta-transaction-based transfers with random nonces and replay protection.
+keywords:
+  - cip
+  - cip-3009
+  - cbc
+  - meta-transactions
+  - authorization
+  - signature
+  - energyless
+  - standard
+author: Rastislav Vašička <rastislav@onion.email>
+lang: en-US
+status: draft
+tags:
+  - cbc
+date: 2025-07-07T00:00:00.000Z
+requires:
+  - cip-20
+  - cip-712
+---
+
+Transfer With Authorization for CBC-20 and compatible tokens.
+
+<!--truncate-->
+
+## Abstract
+
+A set of functions to enable meta-transactions and atomic interactions with CBC-20 token contracts via signatures conforming to the CIP-712 typed message signing specification.
+
+This enables the user to:
+
+- delegate the energy payment to someone else,
+- pay for energy in the token itself rather than in CBC,
+- perform one or more token transfers and other operations in a single atomic transaction,
+- transfer CBC-20 tokens to another address, and have the recipient submit the transaction,
+- batch multiple transactions with minimal overhead, and
+- create and perform multiple transactions without having to worry about them failing due to accidental nonce-reuse or improper ordering by the miner.
+
+## Motivation
+
+There is an existing spec, CIP-2612, that also allows meta-transactions, and it is encouraged that a contract implements both for maximum compatibility. The two primary differences between this spec and CIP-2612 are that:
+
+- CIP-2612 uses sequential nonces, but this uses random 32-byte nonces, and that
+- CIP-2612 relies on the CBC-20 `approve`/`transferFrom` ("CBC-20 allowance") pattern.
+
+The biggest issue with the use of sequential nonces is that it does not allow users to perform more than one transaction at time without risking their transactions failing, because:
+
+- DApps may unintentionally reuse nonces that have not yet been processed in the blockchain.
+- Miners may process the transactions in the incorrect order.
+
+This can be especially problematic if the energy prices are very high and transactions often get queued up and remain unconfirmed for a long time. Non-sequential nonces allow users to create as many transactions as they want at the same time.
+
+The CBC-20 allowance mechanism is susceptible to the multiple withdrawal attack, and encourages antipatterns such as the use of the "infinite" allowance. The wide-prevalence of upgradeable contracts have made the conditions favorable for these attacks to happen in the wild.
+
+The deficiencies of the CBC-20 allowance pattern brought about the development of alternative token standards such as the CBC-777 and CBC-677. However, they haven't been able to gain much adoption due to compatibility and potential security issues.
+
+## Specification
+
+### Event
+
+```solidity
+event AuthorizationUsed(
+    address indexed authorizer,
+    bytes32 indexed nonce
+);
+
+// sha256("TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)")
+bytes32 public constant TRANSFER_WITH_AUTHORIZATION_TYPEHASH = 0x7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a2267;
+
+// sha256("ReceiveWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)")
+bytes32 public constant RECEIVE_WITH_AUTHORIZATION_TYPEHASH = 0xd099cc98ef71107a616c4f0f941f04c322d8e254fe26b3c6668db87aae413de8;
+
+/**
+ * @notice Returns the state of an authorization
+ * @dev Nonces are randomly generated 32-byte data unique to the authorizer's
+ * address
+ * @param authorizer    Authorizer's address
+ * @param nonce         Nonce of the authorization
+ * @return True if the nonce is used
+ */
+function authorizationState(
+    address authorizer,
+    bytes32 nonce
+) external view returns (bool);
+
+/**
+ * @notice Execute a transfer with a signed authorization
+ * @param from          Payer's address (Authorizer)
+ * @param to            Payee's address
+ * @param value         Amount to be transferred
+ * @param validAfter    The time after which this is valid (unix time)
+ * @param validBefore   The time before which this is valid (unix time)
+ * @param nonce         Unique nonce
+ * @param v             v of the signature
+ * @param r             r of the signature
+ * @param s             s of the signature
+ */
+function transferWithAuthorization(
+    address from,
+    address to,
+    uint256 value,
+    uint256 validAfter,
+    uint256 validBefore,
+    bytes32 nonce,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+) external;
+
+/**
+ * @notice Receive a transfer with a signed authorization from the payer
+ * @dev This has an additional check to ensure that the payee's address matches
+ * the caller of this function to prevent front-running attacks. (See security
+ * considerations)
+ * @param from          Payer's address (Authorizer)
+ * @param to            Payee's address
+ * @param value         Amount to be transferred
+ * @param validAfter    The time after which this is valid (unix time)
+ * @param validBefore   The time before which this is valid (unix time)
+ * @param nonce         Unique nonce
+ * @param v             v of the signature
+ * @param r             r of the signature
+ * @param s             s of the signature
+ */
+function receiveWithAuthorization(
+    address from,
+    address to,
+    uint256 value,
+    uint256 validAfter,
+    uint256 validBefore,
+    bytes32 nonce,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+) external;
+```
+
+**Optional:**
+
+```solidity
+event AuthorizationCanceled(
+    address indexed authorizer,
+    bytes32 indexed nonce
+);
+
+// sha256("CancelAuthorization(address authorizer,bytes32 nonce)")
+bytes32 public constant CANCEL_AUTHORIZATION_TYPEHASH = 0x158b0a9edf7a828aad02f63cd515c68ef2f50ba807396f6d12842833a1597429;
+
+/**
+ * @notice Attempt to cancel an authorization
+ * @param authorizer    Authorizer's address
+ * @param nonce         Nonce of the authorization
+ * @param v             v of the signature
+ * @param r             r of the signature
+ * @param s             s of the signature
+ */
+function cancelAuthorization(
+    address authorizer,
+    bytes32 nonce,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+) external;
+```
+
+The arguments `v`, `r`, and `s` must be obtained using the CIP-712 typed message signing spec.
+
+**Example:**
+
+```solidity
+DomainSeparator := Sha256(ABIEncode(
+  Sha256(
+    "CIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+  ),
+  Sha256("USD Coin"),                      // name
+  Sha256("2"),                             // version
+  1,                                          // chainId
+  0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48  // verifyingContract
+))
+```
+
+With the domain separator, the typehash, which is used to identify the type of the CIP-712 message being used, and the values of the parameters, you are able to derive a Sha-256 hash digest which can then be signed using the token holder's private key.
+
+**Example:**
+
+```solidity
+// Transfer With Authorization
+TypeHash := Sha256(
+  "TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+)
+Params := { From, To, Value, ValidAfter, ValidBefore, Nonce }
+
+// ReceiveWithAuthorization
+TypeHash := Sha256(
+  "ReceiveWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+)
+Params := { From, To, Value, ValidAfter, ValidBefore, Nonce }
+
+// CancelAuthorization
+TypeHash := Sha256(
+  "CancelAuthorization(address authorizer,bytes32 nonce)"
+)
+Params := { Authorizer, Nonce }
+```
+
+```solidity
+// "‖" denotes concatenation.
+Digest := Keecak256(
+  0x1901 ‖ DomainSeparator ‖ Sha256(ABIEncode(TypeHash, Params...))
+)
+
+{ v, r, s } := Sign(Digest, PrivateKey)
+```
+
+Smart contract functions that wrap `receiveWithAuthorization` call may choose to reduce the number of arguments by accepting the full ABI-encoded set of arguments for the `receiveWithAuthorization` call as a single argument of the type `bytes`.
+
+**Example:**
+
+```solidity
+// sha256("receiveWithAuthorization(address,address,uint256,uint256,uint256,bytes32,uint8,bytes32,bytes32)")[0:4]
+bytes4 private constant _RECEIVE_WITH_AUTHORIZATION_SELECTOR = 0xef55bec6;
+
+function deposit(address token, bytes calldata receiveAuthorization)
+    external
+    nonReentrant
+{
+    (address from, address to, uint256 amount) = abi.decode(
+        receiveAuthorization[0:96],
+        (address, address, uint256)
+    );
+    require(to == address(this), "Recipient is not this contract");
+
+    (bool success, ) = token.call(
+        abi.encodePacked(
+            _RECEIVE_WITH_AUTHORIZATION_SELECTOR,
+            receiveAuthorization
+        )
+    );
+    require(success, "Failed to transfer tokens");
+
+    ...
+}
+```
+
+### Use with web3 providers
+
+The signature for an authorization can be obtained using a web3 provider with the `eth_signTypedData{_v4}` method.
+
+**Example:**
+
+```javascript
+const data = {
+  types: {
+    CIP712Domain: [
+      { name: "name", type: "string" },
+      { name: "version", type: "string" },
+      { name: "chainId", type: "uint256" },
+      { name: "verifyingContract", type: "address" },
+    ],
+    TransferWithAuthorization: [
+      { name: "from", type: "address" },
+      { name: "to", type: "address" },
+      { name: "value", type: "uint256" },
+      { name: "validAfter", type: "uint256" },
+      { name: "validBefore", type: "uint256" },
+      { name: "nonce", type: "bytes32" },
+    ],
+  },
+  domain: {
+    name: tokenName,
+    version: tokenVersion,
+    chainId: selectedChainId,
+    verifyingContract: tokenAddress,
+  },
+  primaryType: "TransferWithAuthorization",
+  message: {
+    from: userAddress,
+    to: recipientAddress,
+    value: amountBN.toString(10),
+    validAfter: 0,
+    validBefore: Math.floor(Date.now() / 1000) + 3600, // Valid for an hour
+    nonce: Web3.utils.randomHex(32),
+  },
+};
+
+const signature = await ethereum.request({
+  method: "eth_signTypedData_v4",
+  params: [userAddress, JSON.stringify(data)],
+});
+
+const v = "0x" + signature.slice(130, 132);
+const r = signature.slice(0, 66);
+const s = "0x" + signature.slice(66, 130);
+```
+
+## Rationale
+
+### Unique Random Nonce, Instead of Sequential Nonce
+
+One might say transaction ordering is one reason why sequential nonces are preferred. However, sequential nonces do not actually help achieve transaction ordering for meta transactions in practice:
+
+- For native Ethereum transactions, when a transaction with a nonce value that is too-high is submitted to the network, it will stay pending until the transactions consuming the lower unused nonces are confirmed.
+- However, for meta-transactions, when a transaction containing a sequential nonce value that is too high is submitted, instead of staying pending, it will revert and fail immediately, resulting in wasted energy.
+- The fact that miners can also reorder transactions and include them in the block in the order they want (assuming each transaction was submitted to the network by different meta-transaction relayers) also makes it possible for the meta-transactions to fail even if the nonces used were correct. (e.g. User submits nonces 3, 4 and 5, but miner ends up including them in the block as 4,5,3, resulting in only 3 succeeding)
+- Lastly, when using different applications simultaneously, in absence of some sort of an off-chain nonce-tracker, it is not possible to determine what the correct next nonce value is if there exists nonces that are used but haven't been submitted and confirmed by the network.
+- Under high energy price conditions, transactions can often "get stuck" in the pool for a long time. Under such a situation, it is much more likely for the same nonce to be unintentionally reused twice. For example, if you make a meta-transaction that uses a sequential nonce from one app, and switch to another app to make another meta-transaction before the previous one confirms, the same nonce will be used if the app relies purely on the data available on-chain, resulting in one of the transactions failing.
+- In conclusion, the only way to guarantee transaction ordering is for relayers to submit transactions one at a time, waiting for confirmation between each submission (and the order in which they should be submitted can be part of some off-chain metadata), rendering sequential nonce irrelevant.
+
+### Valid After and Valid Before
+
+- Relying on relayers to submit transactions for you means you may not have exact control over the timing of transaction submission.
+- These parameters allow the user to schedule a transaction to be only valid in the future or before a specific deadline, protecting the user from potential undesirable effects that may be caused by the submission being made either too late or too early.
+
+### CIP-712
+
+- CIP-712 ensures that the signatures generated are valid only for this specific instance of the token contract and cannot be replayed on a different network with a different chain ID.
+- This is achieved by incorporating the contract address and the chain ID in a Sha-256 hash digest called the domain separator. The actual set of parameters used to derive the domain separator is up to the implementing contract, but it is highly recommended that the fields `verifyingContract` and `chainId` are included.
+
+## Backwards Compatibility
+
+New contracts benefit from being able to directly utilize CIP-3009 in order to create atomic transactions, but existing contracts may still rely on the conventional CBC-20 allowance pattern (`approve`/`transferFrom`).
+
+In order to add support for CIP-3009 to existing contracts ("parent contract") that use the CBC-20 allowance pattern, a forwarding contract ("forwarder") can be constructed that takes an authorization and does the following:
+
+1. Extract the user and deposit amount from the authorization
+2. Call `receiveWithAuthorization` to transfer specified funds from the user to the forwarder
+3. Approve the parent contract to spend funds from the forwarder
+4. Call the method on the parent contract that spends the allowance set from the forwarder
+5. Transfer the ownership of any resulting tokens back to the user
+
+**Example:**
+
+```solidity
+interface IDeFiToken {
+    function deposit(uint256 amount) external returns (uint256);
+
+    function transfer(address account, uint256 amount)
+        external
+        returns (bool);
+}
+
+contract DepositForwarder {
+    bytes4 private constant _RECEIVE_WITH_AUTHORIZATION_SELECTOR = 0xef55bec6;
+
+    IDeFiToken private _parent;
+    ICBC20 private _token;
+
+    constructor(IDeFiToken parent, ICBC20 token) public {
+        _parent = parent;
+        _token = token;
+    }
+
+    function deposit(bytes calldata receiveAuthorization)
+        external
+        nonReentrant
+        returns (uint256)
+    {
+        (address from, address to, uint256 amount) = abi.decode(
+            receiveAuthorization[0:96],
+            (address, address, uint256)
+        );
+        require(to == address(this), "Recipient is not this contract");
+
+        (bool success, ) = address(_token).call(
+            abi.encodePacked(
+                _RECEIVE_WITH_AUTHORIZATION_SELECTOR,
+                receiveAuthorization
+            )
+        );
+        require(success, "Failed to transfer to the forwarder");
+
+        require(
+            _token.approve(address(_parent), amount),
+            "Failed to set the allowance"
+        );
+
+        uint256 tokensMinted = _parent.deposit(amount);
+        require(
+            _parent.transfer(from, tokensMinted),
+            "Failed to transfer the minted tokens"
+        );
+
+        uint256 remainder = _token.balanceOf(address(this);
+        if (remainder > 0) {
+            require(
+                _token.transfer(from, remainder),
+                "Failed to refund the remainder"
+            );
+        }
+
+        return tokensMinted;
+    }
+}
+```
+
+## Implementation
+
+### CIP3009.sol
+
+```solidity
+abstract contract CIP3009 is ICBC20Transfer, CIP712Domain {
+    // sha256("TransferWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)")
+    bytes32 public constant TRANSFER_WITH_AUTHORIZATION_TYPEHASH = 0x7c7c6cdb67a18743f49ec6fa9b35f50d52ed05cbed4cc592e13b44501c1a2267;
+
+    // sha256("ReceiveWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)")
+    bytes32 public constant RECEIVE_WITH_AUTHORIZATION_TYPEHASH = 0xd099cc98ef71107a616c4f0f941f04c322d8e254fe26b3c6668db87aae413de8;
+
+    mapping(address => mapping(bytes32 => bool)) internal _authorizationStates;
+
+    event AuthorizationUsed(address indexed authorizer, bytes32 indexed nonce);
+
+    string internal constant _INVALID_SIGNATURE_ERROR = "CIP3009: invalid signature";
+
+    function authorizationState(address authorizer, bytes32 nonce)
+        external
+        view
+        returns (bool)
+    {
+        return _authorizationStates[authorizer][nonce];
+    }
+
+    function transferWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        require(now > validAfter, "CIP3009: authorization is not yet valid");
+        require(now < validBefore, "CIP3009: authorization is expired");
+        require(
+            !_authorizationStates[from][nonce],
+            "CIP3009: authorization is used"
+        );
+
+        bytes memory data = abi.encode(
+            TRANSFER_WITH_AUTHORIZATION_TYPEHASH,
+            from,
+            to,
+            value,
+            validAfter,
+            validBefore,
+            nonce
+        );
+        require(
+            CIP712.recover(DOMAIN_SEPARATOR, v, r, s, data) == from,
+            "CIP3009: invalid signature"
+        );
+
+        _authorizationStates[from][nonce] = true;
+        emit AuthorizationUsed(from, nonce);
+
+        _transfer(from, to, value);
+    }
+}
+```
+
+### ICBC20Transfer.sol
+
+```solidity
+abstract contract ICBC20Transfer {
+    function _transfer(
+        address sender,
+        address recipient,
+        uint256 amount
+    ) internal virtual;
+}
+```
+
+### CIP712Domain.sol
+
+```solidity
+abstract contract CIP712Domain {
+    bytes32 public DOMAIN_SEPARATOR;
+}
+```
+
+### CIP712.sol
+
+```solidity
+library CIP712 {
+    // sha256("CIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
+    bytes32 public constant CIP712_DOMAIN_TYPEHASH = 0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
+
+    function makeDomainSeparator(string memory name, string memory version)
+        internal
+        view
+        returns (bytes32)
+    {
+        uint256 chainId;
+        assembly {
+            chainId := chainid()
+        }
+
+        return
+            sha256(
+                abi.encode(
+                    CIP712_DOMAIN_TYPEHASH,
+                    sha256(bytes(name)),
+                    sha256(bytes(version)),
+                    address(this),
+                    bytes32(chainId)
+                )
+            );
+    }
+
+    function recover(
+        bytes32 domainSeparator,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes memory typeHashAndData
+    ) internal pure returns (address) {
+        bytes32 digest = sha256(
+            abi.encodePacked(
+                "\x19\x01",
+                domainSeparator,
+                sha256(typeHashAndData)
+            )
+        );
+        address recovered = ecrecover(digest, v, r, s);
+        require(recovered != address(0), "CIP712: invalid signature");
+        return recovered;
+    }
+}
+```
+
+## Security Considerations
+
+Use `receiveWithAuthorization` instead of `transferWithAuthorization` when calling from other smart contracts. It is possible for an attacker watching the transaction pool to extract the transfer authorization and front-run the `transferWithAuthorization` call to execute the transfer without invoking the wrapper function. This could potentially result in unprocessed, locked up deposits. `receiveWithAuthorization` prevents this by performing an additional check that ensures that the caller is the payee. Additionally, if there are multiple contract functions accepting receive authorizations, the app developer could dedicate some leading bytes of the nonce could as the identifier to prevent cross-use.
+
+When submitting multiple transfers simultaneously, be mindful of the fact that relayers and miners will decide the order in which they are processed. This is generally not a problem if the transactions are not dependent on each other, but for transactions that are highly dependent on each other, it is recommended that the signed authorizations are submitted one at a time.
+
+The zero address must be rejected when using `ecrecover` to prevent unauthorized transfers and approvals of funds from the zero address. The built-in `ecrecover` returns the zero address when a malformed signature is provided.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cip/cbc/cip-4626.md
+++ b/cip/cbc/cip-4626.md
@@ -1,0 +1,621 @@
+---
+cip: 4626
+title: Tokenized Vaults Standard
+description: >-
+  A standardized smart contract interface for tokenized vaults with a single underlying CBC-20 token, supporting deposit, withdrawal, and share accounting.
+keywords:
+  - cip
+  - cip-4626
+  - cbc
+  - vault
+  - tokenized vault
+  - yield
+  - standard
+  - cbc-20
+  - asset management
+author: Rastislav Vašička <rastislav@onion.email>
+lang: en-US
+status: draft
+tags:
+  - cbc
+date: 2025-07-06T00:00:00.000Z
+requires:
+  - cip-20
+  - cip-2612
+---
+
+A standardized smart contract interface for tokenized vaults with a single underlying CBC-20 token, supporting deposit, withdrawal, and share accounting.
+
+<!--truncate-->
+
+## Abstract
+
+The following standard allows for the implementation of a standard API for tokenized Vaults
+representing shares of a single underlying CIP-20 token.
+This standard is an extension on the CIP-20 token that provides basic functionality for depositing
+and withdrawing tokens and reading balances.
+
+## Motivation
+
+Tokenized Vaults have a lack of standardization leading to diverse implementation details.
+Some various examples include lending markets, aggregators, and intrinsically interest bearing tokens.
+This makes integration difficult at the aggregator or plugin layer for protocols which need to conform to many standards, and forces each protocol to implement their own adapters which are error prone and waste development resources.
+
+A standard for tokenized Vaults will lower the integration effort for yield-bearing vaults, while creating more consistent and robust implementation patterns.
+
+## Specification
+
+All CIP-4626 tokenized Vaults MUST implement CIP-20 to represent shares.
+If a Vault is to be non-transferrable, it MAY revert on calls to `transfer` or `transferFrom`.
+The CIP-20 operations `balanceOf`, `transfer`, `totalSupply`, etc. operate on the Vault "shares"
+which represent a claim to ownership on a fraction of the Vault's underlying holdings.
+
+All CIP-4626 tokenized Vaults MUST implement CIP-20's optional metadata extensions.
+The `name` and `symbol` functions SHOULD reflect the underlying token's `name` and `symbol` in some way.
+
+CIP-4626 tokenized Vaults MAY implement CIP-2612 to improve the UX of approving shares on various integrations.
+
+### Definitions
+
+- asset: The underlying token managed by the Vault.
+  Has units defined by the corresponding CIP-20 contract.
+- share: The token of the Vault. Has a ratio of underlying assets
+  exchanged on mint/deposit/withdraw/redeem (as defined by the Vault).
+- fee: An amount of assets or shares charged to the user by the Vault. Fees can exists for
+  deposits, yield, AUM, withdrawals, or anything else prescribed by the Vault.
+- slippage: Any difference between advertised share price and economic realities of
+  deposit to or withdrawal from the Vault, which is not accounted by fees.
+
+### Methods
+
+#### asset
+
+The address of the underlying token used for the Vault for accounting, depositing, and withdrawing.
+
+MUST be an CIP-20 token contract.
+
+MUST _NOT_ revert.
+
+```yaml
+- name: asset
+  type: function
+  stateMutability: view
+
+  inputs: []
+
+  outputs:
+    - name: assetTokenAddress
+      type: address
+```
+
+#### totalAssets
+
+Total amount of the underlying asset that is "managed" by Vault.
+
+SHOULD include any compounding that occurs from yield.
+
+MUST be inclusive of any fees that are charged against assets in the Vault.
+
+MUST _NOT_ revert.
+
+```yaml
+- name: totalAssets
+  type: function
+  stateMutability: view
+
+  inputs: []
+
+  outputs:
+    - name: totalManagedAssets
+      type: uint256
+```
+
+#### convertToShares
+
+The amount of shares that the Vault would exchange for the amount of assets provided, in an ideal scenario where all the conditions are met.
+
+MUST NOT be inclusive of any fees that are charged against assets in the Vault.
+
+MUST NOT show any variations depending on the caller.
+
+MUST NOT reflect slippage or other on-chain conditions, when performing the actual exchange.
+
+MUST NOT revert unless due to integer overflow caused by an unreasonably large input.
+
+MUST round down towards 0.
+
+This calculation MAY NOT reflect the "per-user" price-per-share, and instead should reflect the "average-user's" price-per-share, meaning what the average user should expect to see when exchanging to and from.
+
+```yaml
+- name: convertToShares
+  type: function
+  stateMutability: view
+
+  inputs:
+    - name: assets
+      type: uint256
+
+  outputs:
+    - name: shares
+      type: uint256
+```
+
+#### convertToAssets
+
+The amount of assets that the Vault would exchange for the amount of shares provided, in an ideal scenario where all the conditions are met.
+
+MUST NOT be inclusive of any fees that are charged against assets in the Vault.
+
+MUST NOT show any variations depending on the caller.
+
+MUST NOT reflect slippage or other on-chain conditions, when performing the actual exchange.
+
+MUST NOT revert unless due to integer overflow caused by an unreasonably large input.
+
+MUST round down towards 0.
+
+This calculation MAY NOT reflect the "per-user" price-per-share, and instead should reflect the "average-user's" price-per-share, meaning what the average user should expect to see when exchanging to and from.
+
+```yaml
+- name: convertToAssets
+  type: function
+  stateMutability: view
+
+  inputs:
+    - name: shares
+      type: uint256
+
+  outputs:
+    - name: assets
+      type: uint256
+```
+
+#### maxDeposit
+
+Maximum amount of the underlying asset that can be deposited into the Vault for the `receiver`, through a `deposit` call.
+
+MUST return the maximum amount of assets `deposit` would allow to be deposited for `receiver` and not cause a revert, which MUST NOT be higher than the actual maximum that would be accepted (it should underestimate if necessary). This assumes that the user has infinite assets, i.e. MUST NOT rely on `balanceOf` of `asset`.
+
+MUST factor in both global and user-specific limits, like if deposits are entirely disabled (even temporarily) it MUST return 0.
+
+MUST return `2 ** 256 - 1` if there is no limit on the maximum amount of assets that may be deposited.
+
+MUST NOT revert.
+
+```yaml
+- name: maxDeposit
+  type: function
+  stateMutability: view
+
+  inputs:
+    - name: receiver
+      type: address
+
+  outputs:
+    - name: maxAssets
+      type: uint256
+```
+
+#### previewDeposit
+
+Allows an on-chain or off-chain user to simulate the effects of their deposit at the current block, given current on-chain conditions.
+
+MUST return as close to and no more than the exact amount of Vault shares that would be minted in a `deposit` call in the same transaction. I.e. `deposit` should return the same or more `shares` as `previewDeposit` if called in the same transaction.
+
+MUST NOT account for deposit limits like those returned from maxDeposit and should always act as though the deposit would be accepted, regardless if the user has enough tokens approved, etc.
+
+MUST be inclusive of deposit fees. Integrators should be aware of the existence of deposit fees.
+
+MUST NOT revert due to vault specific user/global limits. MAY revert due to other conditions that would also cause `deposit` to revert.
+
+Note that any unfavorable discrepancy between `convertToShares` and `previewDeposit` SHOULD be considered slippage in share price or some other type of condition, meaning the depositor will lose assets by depositing.
+
+```yaml
+- name: previewDeposit
+  type: function
+  stateMutability: view
+
+  inputs:
+    - name: assets
+      type: uint256
+
+  outputs:
+    - name: shares
+      type: uint256
+```
+
+#### deposit
+
+Mints `shares` Vault shares to `receiver` by depositing exactly `assets` of underlying tokens.
+
+MUST emit the `Deposit` event.
+
+MUST support CIP-20 `approve` / `transferFrom` on `asset` as a deposit flow.
+MAY support an additional flow in which the underlying tokens are owned by the Vault contract before the `deposit` execution, and are accounted for during `deposit`.
+
+MUST revert if all of `assets` cannot be deposited (due to deposit limit being reached, slippage, the user not approving enough underlying tokens to the Vault contract, etc).
+
+Note that most implementations will require pre-approval of the Vault with the Vault's underlying `asset` token.
+
+```yaml
+- name: deposit
+  type: function
+  stateMutability: nonpayable
+
+  inputs:
+    - name: assets
+      type: uint256
+    - name: receiver
+      type: address
+
+  outputs:
+    - name: shares
+      type: uint256
+```
+
+#### maxMint
+
+Maximum amount of shares that can be minted from the Vault for the `receiver`, through a `mint` call.
+
+MUST return the maximum amount of shares `mint` would allow to be deposited to `receiver` and not cause a revert, which MUST NOT be higher than the actual maximum that would be accepted (it should underestimate if necessary). This assumes that the user has infinite assets, i.e. MUST NOT rely on `balanceOf` of `asset`.
+
+MUST factor in both global and user-specific limits, like if mints are entirely disabled (even temporarily) it MUST return 0.
+
+MUST return `2 ** 256 - 1` if there is no limit on the maximum amount of shares that may be minted.
+
+MUST NOT revert.
+
+```yaml
+- name: maxMint
+  type: function
+  stateMutability: view
+
+  inputs:
+    - name: receiver
+      type: address
+
+  outputs:
+    - name: maxShares
+      type: uint256
+```
+
+#### previewMint
+
+Allows an on-chain or off-chain user to simulate the effects of their mint at the current block, given current on-chain conditions.
+
+MUST return as close to and no fewer than the exact amount of assets that would be deposited in a `mint` call in the same transaction. I.e. `mint` should return the same or fewer `assets` as `previewMint` if called in the same transaction.
+
+MUST NOT account for mint limits like those returned from maxMint and should always act as though the mint would be accepted, regardless if the user has enough tokens approved, etc.
+
+MUST be inclusive of deposit fees. Integrators should be aware of the existence of deposit fees.
+
+MUST NOT revert due to vault specific user/global limits. MAY revert due to other conditions that would also cause `mint` to revert.
+
+Note that any unfavorable discrepancy between `convertToAssets` and `previewMint` SHOULD be considered slippage in share price or some other type of condition, meaning the depositor will lose assets by minting.
+
+```yaml
+- name: previewMint
+  type: function
+  stateMutability: view
+
+  inputs:
+    - name: shares
+      type: uint256
+
+  outputs:
+    - name: assets
+      type: uint256
+```
+
+#### mint
+
+Mints exactly `shares` Vault shares to `receiver` by depositing `assets` of underlying tokens.
+
+MUST emit the `Deposit` event.
+
+MUST support CIP-20 `approve` / `transferFrom` on `asset` as a mint flow.
+MAY support an additional flow in which the underlying tokens are owned by the Vault contract before the `mint` execution, and are accounted for during `mint`.
+
+MUST revert if all of `shares` cannot be minted (due to deposit limit being reached, slippage, the user not approving enough underlying tokens to the Vault contract, etc).
+
+Note that most implementations will require pre-approval of the Vault with the Vault's underlying `asset` token.
+
+```yaml
+- name: mint
+  type: function
+  stateMutability: nonpayable
+
+  inputs:
+    - name: shares
+      type: uint256
+    - name: receiver
+      type: address
+
+  outputs:
+    - name: assets
+      type: uint256
+```
+
+#### maxWithdraw
+
+Maximum amount of the underlying asset that can be withdrawn from the `owner` balance in the Vault, through a `withdraw` call.
+
+MUST return the maximum amount of assets that could be transferred from `owner` through `withdraw` and not cause a revert, which MUST NOT be higher than the actual maximum that would be accepted (it should underestimate if necessary).
+
+MUST factor in both global and user-specific limits, like if withdrawals are entirely disabled (even temporarily) it MUST return 0.
+
+MUST NOT revert.
+
+```yaml
+- name: maxWithdraw
+  type: function
+  stateMutability: view
+
+  inputs:
+    - name: owner
+      type: address
+
+  outputs:
+    - name: maxAssets
+      type: uint256
+```
+
+#### previewWithdraw
+
+Allows an on-chain or off-chain user to simulate the effects of their withdrawal at the current block, given current on-chain conditions.
+
+MUST return as close to and no fewer than the exact amount of Vault shares that would be burned in a `withdraw` call in the same transaction. I.e. `withdraw` should return the same or fewer `shares` as `previewWithdraw` if called in the same transaction.
+
+MUST NOT account for withdrawal limits like those returned from maxWithdraw and should always act as though the withdrawal would be accepted, regardless if the user has enough shares, etc.
+
+MUST be inclusive of withdrawal fees. Integrators should be aware of the existence of withdrawal fees.
+
+MUST NOT revert due to vault specific user/global limits. MAY revert due to other conditions that would also cause `withdraw` to revert.
+
+Note that any unfavorable discrepancy between `convertToShares` and `previewWithdraw` SHOULD be considered slippage in share price or some other type of condition, meaning the depositor will lose assets by depositing.
+
+```yaml
+- name: previewWithdraw
+  type: function
+  stateMutability: view
+
+  inputs:
+    - name: assets
+      type: uint256
+
+  outputs:
+    - name: shares
+      type: uint256
+```
+
+#### withdraw
+
+Burns `shares` from `owner` and sends exactly `assets` of underlying tokens to `receiver`.
+
+MUST emit the `Withdraw` event.
+
+MUST support a withdraw flow where the shares are burned from `owner` directly where `owner` is `msg.sender`.
+
+MUST support a withdraw flow where the shares are burned from `owner` directly where `msg.sender` has CIP-20 approval over the shares of `owner`.
+
+MAY support an additional flow in which the shares are transferred to the Vault contract before the `withdraw` execution, and are accounted for during `withdraw`.
+
+SHOULD check `msg.sender` can spend owner funds, assets needs to be converted to shares and shares should be checked for allowance.
+
+MUST revert if all of `assets` cannot be withdrawn (due to withdrawal limit being reached, slippage, the owner not having enough shares, etc).
+
+Note that some implementations will require pre-requesting to the Vault before a withdrawal may be performed. Those methods should be performed separately.
+
+```yaml
+- name: withdraw
+  type: function
+  stateMutability: nonpayable
+
+  inputs:
+    - name: assets
+      type: uint256
+    - name: receiver
+      type: address
+    - name: owner
+      type: address
+
+  outputs:
+    - name: shares
+      type: uint256
+```
+
+#### maxRedeem
+
+Maximum amount of Vault shares that can be redeemed from the `owner` balance in the Vault, through a `redeem` call.
+
+MUST return the maximum amount of shares that could be transferred from `owner` through `redeem` and not cause a revert, which MUST NOT be higher than the actual maximum that would be accepted (it should underestimate if necessary).
+
+MUST factor in both global and user-specific limits, like if redemption is entirely disabled (even temporarily) it MUST return 0.
+
+MUST NOT revert.
+
+```yaml
+- name: maxRedeem
+  type: function
+  stateMutability: view
+
+  inputs:
+    - name: owner
+      type: address
+
+  outputs:
+    - name: maxShares
+      type: uint256
+```
+
+#### previewRedeem
+
+Allows an on-chain or off-chain user to simulate the effects of their redeemption at the current block, given current on-chain conditions.
+
+MUST return as close to and no more than the exact amount of assets that would be withdrawn in a `redeem` call in the same transaction. I.e. `redeem` should return the same or more `assets` as `previewRedeem` if called in the same transaction.
+
+MUST NOT account for redemption limits like those returned from maxRedeem and should always act as though the redemption would be accepted, regardless if the user has enough shares, etc.
+
+MUST be inclusive of withdrawal fees. Integrators should be aware of the existence of withdrawal fees.
+
+MUST NOT revert due to vault specific user/global limits. MAY revert due to other conditions that would also cause `redeem` to revert.
+
+Note that any unfavorable discrepancy between `convertToAssets` and `previewRedeem` SHOULD be considered slippage in share price or some other type of condition, meaning the depositor will lose assets by redeeming.
+
+```yaml
+- name: previewRedeem
+  type: function
+  stateMutability: view
+
+  inputs:
+    - name: shares
+      type: uint256
+
+  outputs:
+    - name: assets
+      type: uint256
+```
+
+#### redeem
+
+Burns exactly `shares` from `owner` and sends `assets` of underlying tokens to `receiver`.
+
+MUST emit the `Withdraw` event.
+
+MUST support a redeem flow where the shares are burned from `owner` directly where `owner` is `msg.sender`.
+
+MUST support a redeem flow where the shares are burned from `owner` directly where `msg.sender` has CIP-20 approval over the shares of `owner`.
+
+MAY support an additional flow in which the shares are transferred to the Vault contract before the `redeem` execution, and are accounted for during `redeem`.
+
+SHOULD check `msg.sender` can spend owner funds using allowance.
+
+MUST revert if all of `shares` cannot be redeemed (due to withdrawal limit being reached, slippage, the owner not having enough shares, etc).
+
+Note that some implementations will require pre-requesting to the Vault before a withdrawal may be performed. Those methods should be performed separately.
+
+```yaml
+- name: redeem
+  type: function
+  stateMutability: nonpayable
+
+  inputs:
+    - name: shares
+      type: uint256
+    - name: receiver
+      type: address
+    - name: owner
+      type: address
+
+  outputs:
+    - name: assets
+      type: uint256
+```
+
+### Events
+
+#### Deposit
+
+`sender` has exchanged `assets` for `shares`, and transferred those `shares` to `owner`.
+
+MUST be emitted when tokens are deposited into the Vault via the `mint` and `deposit` methods.
+
+```yaml
+- name: Deposit
+  type: event
+
+  inputs:
+    - name: sender
+      indexed: true
+      type: address
+    - name: owner
+      indexed: true
+      type: address
+    - name: assets
+      indexed: false
+      type: uint256
+    - name: shares
+      indexed: false
+      type: uint256
+```
+
+#### Withdraw
+
+`sender` has exchanged `shares`, owned by `owner`, for `assets`, and transferred those `assets` to `receiver`.
+
+MUST be emitted when shares are withdrawn from the Vault in `CIP-4626.redeem` or `CIP-4626.withdraw` methods.
+
+```yaml
+- name: Withdraw
+  type: event
+
+  inputs:
+    - name: sender
+      indexed: true
+      type: address
+    - name: receiver
+      indexed: true
+      type: address
+    - name: owner
+      indexed: true
+      type: address
+    - name: assets
+      indexed: false
+      type: uint256
+    - name: shares
+      indexed: false
+      type: uint256
+```
+
+## Rationale
+
+The Vault interface is designed to be optimized for integrators with a feature complete yet minimal interface.
+Details such as accounting and allocation of deposited tokens are intentionally not specified,
+as Vaults are expected to be treated as black boxes on-chain and inspected off-chain before use.
+
+CIP-20 is enforced because implementation details like token approval
+and balance calculation directly carry over to the shares accounting.
+This standardization makes the Vaults immediately compatible with all CIP-20 use cases in addition to CIP-4626.
+
+The mint method was included for symmetry and feature completeness.
+Most current use cases of share-based Vaults do not ascribe special meaning to the shares such that
+a user would optimize for a specific number of shares (`mint`) rather than specific amount of underlying (`deposit`).
+However, it is easy to imagine future Vault strategies which would have unique and independently useful share representations.
+
+The `convertTo` functions serve as rough estimates that do not account for operation specific details like withdrawal fees, etc.
+They were included for frontends and applications that need an average value of shares or assets, not an exact value possibly including slippage or other fees.
+For applications that need an exact value that attempts to account for fees and slippage we have included a corresponding `preview` function to match each mutable function. These functions must not account for deposit or withdrawal limits, to ensure they are easily composable, the `max` functions are provided for that purpose.
+
+## Backwards Compatibility
+
+CIP-4626 is fully backward compatible with the CIP-20 standard and has no known compatibility issues with other standards.
+For production implementations of Vaults which do not use CIP-4626, wrapper adapters can be developed and used.
+
+## Security Considerations
+
+Fully permissionless use cases could fall prey to malicious implementations which only conform to the interface but not the specification.
+It is recommended that all integrators review the implementation for potential ways of losing user deposits before integrating.
+
+If implementors intend to support EOA account access directly, they should consider adding an additional function call for `deposit`/`mint`/`withdraw`/`redeem` with the means to accommodate slippage loss or unexpected deposit/withdrawal limits, since they have no other means to revert the transaction if the exact output amount is not achieved.
+
+The methods `totalAssets`, `convertToShares` and `convertToAssets` are estimates useful for display purposes,
+and do _not_ have to confer the _exact_ amount of underlying assets their context suggests.
+
+The `preview` methods return values that are as close as possible to exact as possible. For that reason, they are manipulable by altering the on-chain conditions and are not always safe to be used as price oracles. This specification includes `convert` methods that are allowed to be inexact and therefore can be implemented as robust price oracles. For example, it would be correct to implement the `convert` methods as using a time-weighted average price in converting between assets and shares.
+
+Integrators of CIP-4626 Vaults should be aware of the difference between these view methods when integrating with this standard. Additionally, note that the amount of underlying assets a user may receive from redeeming their Vault shares (`previewRedeem`) can be significantly different than the amount that would be taken from them when minting the same quantity of shares (`previewMint`). The differences may be small (like if due to rounding error), or very significant (like if a Vault implements withdrawal or deposit fees, etc). Therefore integrators should always take care to use the preview function most relevant to their use case, and never assume they are interchangeable.
+
+Finally, CIP-4626 Vault implementers should be aware of the need for specific, opposing rounding directions across the different mutable and view methods, as it is considered most secure to favor the Vault itself during calculations over its users:
+
+- If (1) it's calculating how many shares to issue to a user for a certain amount of the underlying tokens they provide or (2) it's determining the amount of the underlying tokens to transfer to them for returning a certain amount of shares, it should round _down_.
+
+- If (1) it's calculating the amount of shares a user has to supply to receive a given amount of the underlying tokens or (2) it's calculating the amount of underlying tokens a user has to provide to receive a certain amount of shares, it should round _up_.
+
+The only functions where the preferred rounding direction would be ambiguous are the `convertTo` functions. To ensure consistency across all CIP-4626 Vault implementations it is specified that these functions MUST both always round _down_. Integrators may wish to mimic rounding up versions of these functions themselves, like by adding 1 wei to the result.
+
+Although the `convertTo` functions should eliminate the need for any use of an CIP-4626 Vault's `decimals` variable, it is still strongly recommended to mirror
+the underlying token's `decimals` if at all possible, to eliminate possible sources of confusion and simplify integration across front-ends and for other off-chain users.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/cip/cbc/cip-721.md
+++ b/cip/cbc/cip-721.md
@@ -126,9 +126,9 @@ interface CBC721Enumerable /* is CBC721 */ {
 
 ## Design Considerations
 
-### Why Not ERC-20?
+### Why Not CBC-20?
 
-Each CoreNFT is **non-fungible** — unique and not interchangeable. Unlike ERC-20 (or Core20) tokens, each NFT has individual ownership, metadata, and identity.
+Each CoreNFT is **non-fungible** — unique and not interchangeable. Unlike CBC-20 (or Core20) tokens, each NFT has individual ownership, metadata, and identity.
 
 ### Identification
 
@@ -165,7 +165,7 @@ This standard is designed to be compatible with existing NFT implementations and
 * Implement proper access controls for transfer and approval functions
 * Use safe transfer methods when interacting with smart contracts
 * Validate token ownership before allowing transfers
-* Consider gas optimization for batch operations
+* Consider energy optimization for batch operations
 * Ensure proper error handling for edge cases
 
 ## Conclusion

--- a/cip/cbc/cip-777.md
+++ b/cip/cbc/cip-777.md
@@ -1,0 +1,149 @@
+---
+cip: 777
+title: Token Standard
+description: >-
+  A standardized smart contract interface for advanced token functionality on Core Blockchain (CBC), supporting operators, hooks, and improved composability over CBC-20.
+keywords:
+  - cip
+  - cip-777
+  - cbc
+  - token
+  - operator
+  - hooks
+  - composability
+  - standard
+author: Rastislav Vašička <rastislav@onion.email>
+lang: en-US
+status: draft
+tags:
+  - cbc
+date: 2025-07-06T00:00:00.000Z
+requires:
+  - cip-20
+  - cip-165
+---
+
+A standardized smart contract interface for advanced token functionality on Core Blockchain (CBC), supporting operators, hooks, and improved composability over CBC-20.
+
+<!--truncate-->
+
+## Abstract
+
+This standard defines an advanced token interface for Core Blockchain (CBC), introducing operator-based transfers, send/receive hooks, and improved composability compared to CBC-20. CBC-777 enables more flexible and secure token interactions, supporting use cases such as escrow, atomic swaps, and on-chain services.
+
+## Motivation
+
+CBC-20 tokens are widely used but have limitations, such as lack of hooks for sending/receiving tokens and inflexible approval mechanisms. CBC-777 addresses these issues by introducing operators (trusted accounts that can send tokens on behalf of others) and hooks (functions called on send/receive), enabling safer and more powerful token workflows for DeFi, gaming, and enterprise applications.
+
+## Specification
+
+### Interface
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface ICBC777 /* is ICBC165 */ {
+    // --- Events ---
+    event Sent(address indexed operator, address indexed from, address indexed to, uint256 amount, bytes data, bytes operatorData);
+    event Minted(address indexed operator, address indexed to, uint256 amount, bytes data, bytes operatorData);
+    event Burned(address indexed operator, address indexed from, uint256 amount, bytes data, bytes operatorData);
+    event AuthorizedOperator(address indexed operator, address indexed tokenHolder);
+    event RevokedOperator(address indexed operator, address indexed tokenHolder);
+
+    // --- Core Functions ---
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+    function granularity() external view returns (uint256);
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address owner) external view returns (uint256);
+    function send(address to, uint256 amount, bytes calldata data) external;
+    function burn(uint256 amount, bytes calldata data) external;
+    function isOperatorFor(address operator, address tokenHolder) external view returns (bool);
+    function authorizeOperator(address operator) external;
+    function revokeOperator(address operator) external;
+    function operatorSend(address from, address to, uint256 amount, bytes calldata data, bytes calldata operatorData) external;
+    function operatorBurn(address from, uint256 amount, bytes calldata data, bytes calldata operatorData) external;
+    function defaultOperators() external view returns (address[] memory);
+}
+```
+
+### Send and Receive Hooks
+
+Contracts can register as senders or recipients to receive notifications via hooks. Hooks are discovered using CBC-165 interface detection.
+
+```solidity
+interface ICBC777Sender {
+    function tokensToSend(address operator, address from, address to, uint256 amount, bytes calldata data, bytes calldata operatorData) external;
+}
+
+interface ICBC777Recipient {
+    function tokensReceived(address operator, address from, address to, uint256 amount, bytes calldata data, bytes calldata operatorData) external;
+}
+```
+
+#### Hook Registration and Discovery
+
+- Contracts MUST implement CBC-165 and return `true` for the interface IDs of `ICBC777Sender` and/or `ICBC777Recipient` as appropriate.
+- If a hook is not registered, the token contract MUST proceed without calling it.
+- If a hook is registered but reverts, the token transfer MUST revert.
+- If a contract does not implement the hook, tokens may be locked; implementers should take care to avoid accidental lockup.
+
+### Default Operators
+
+- CBC-777 supports a list of default operators (e.g., exchanges, custodians) that are operators for all token holders unless explicitly revoked by a holder.
+- The `defaultOperators()` function returns the list of default operator addresses.
+- Token holders can revoke or re-authorize default operators at any time.
+
+### Method Behaviors
+
+- The `granularity` function MUST return the smallest transferable unit (usually 1). All token amounts MUST be a multiple of granularity.
+- The `send` and `operatorSend` functions MUST call the `tokensToSend` and `tokensReceived` hooks if registered.
+- Operators MAY be authorized or revoked by token holders at any time. Default operators can be revoked per holder.
+- Minting and burning MUST emit the appropriate events.
+- Contracts implementing CBC-777 MUST implement CBC-165 `supportsInterface`.
+- For CBC-20 compatibility, contracts MAY emit `Transfer` and `Approval` events as appropriate.
+
+### Operator Authorization and Revocation
+
+- Any address can be authorized as an operator by a token holder using `authorizeOperator`.
+- Operators can be revoked at any time using `revokeOperator`.
+- The `isOperatorFor` function returns `true` if the operator is authorized for the token holder, either directly or as a default operator (unless revoked).
+- Operators can call `operatorSend` and `operatorBurn` on behalf of the token holder.
+
+### Granularity and Decimals
+
+- `granularity()` defines the smallest transferable unit. For most tokens, this MUST be 1.
+- CBC-777 does not require a `decimals()` function, but it MAY be implemented for compatibility with CBC-20.
+
+### Events
+
+- All token movements (send, mint, burn) MUST emit the appropriate events (`Sent`, `Minted`, `Burned`).
+- Operator authorization and revocation MUST emit `AuthorizedOperator` and `RevokedOperator` events.
+- For CBC-20 compatibility, `Transfer` and `Approval` events MAY be emitted.
+
+## Reference Implementation
+
+A reference implementation can be provided upon request, following the CBC-777 interface and best practices for hooks and operator management.
+
+## Rationale
+
+CBC-777 improves on CBC-20 by enabling advanced token flows, such as escrow, atomic swaps, and on-chain services, through hooks and operator permissions. Default operators simplify integration with custodians and exchanges. This design increases security and composability for modern dApps.
+
+## Backward Compatibility
+
+CBC-777 is backward compatible with CBC-20. Implementers MAY include CBC-20 functions and events for compatibility with existing wallets and dApps. Dual implementation is recommended for maximum interoperability.
+
+## Security Considerations
+
+- Implementers must ensure hooks are only called on contracts that register for them (using CBC-165).
+- Operator permissions should be managed carefully to prevent unauthorized transfers. Default operators should be chosen with care.
+- Granularity should be set to prevent rounding errors and ensure divisibility is as intended.
+- Upgradability and access control best practices should be followed.
+- Reentrancy: Hooks can call back into the token contract. Use reentrancy guards where appropriate.
+- Accidental token lockup: If tokens are sent to a contract that does not implement `tokensReceived`, they may be locked. User interfaces should warn users.
+- Operator abuse: Token holders should be able to easily view and manage their operators.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Introduces multiple new CBC standards for improved token functionality and metadata handling:

- Defines CBC-1155 for managing multiple token types in a single contract.
- Introduces CBC-1761 for scoped token approval, enabling fine-grained operator permissions.
- Specifies CBC-1820 for a universal interface registry, enhancing contract introspection.
- Standardizes CBC-2535 for modular, upgradeable smart contract systems using diamonds.
- Implements CBC-2612, enabling gasless CBC-20 token approvals via signatures.
- Specifies CBC-3005 for batched meta-transactions.
- Introduces CBC-3009 for authorized token transfers.
- Defines CBC-4626 for tokenized vaults.
- Updates CIP-150 and CIP-151 to be compatible with CBC standards.
- Renames "gas" to "energy" in CIP-108 and CIP-165.