### PR TITLE
Fix GH bug

### DIFF
--- a/.github/workflows/update-frontmatter.yml
+++ b/.github/workflows/update-frontmatter.yml
@@ -34,4 +34,4 @@ jobs:
         git config --global user.name "GitHub Action"
         git add -A
         git diff --staged --quiet || git commit -m "Update front matter tags based on dates"
-        git push origin HEAD:${{ github.ref }}
+        git push origin master


### PR DESCRIPTION
GH has bug with branch protection applied on `HEAD:${{ github.ref }}` - this is fixing it till GH will introduce fix.