### PR TITLE
Removes language filter for Algolia search

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -287,9 +287,6 @@ const config: Config = {
         indexName: process.env.algoliaIndexName,
         contextualSearch: true,
         searchPagePath: 'search',
-        searchParameters: {
-          facetFilters: ['language:en'],
-        },
       },
     } : {}),
   } satisfies Preset.ThemeConfig,


### PR DESCRIPTION
Removes the language facet filter from the Algolia search configuration.

This change allows search results to include content in all languages, providing a broader and more comprehensive search experience for users.